### PR TITLE
Fix uncaught `IndexOutOfBoundsException` due to malformed files

### DIFF
--- a/src/main/java/org/tudo/sse/resolution/JarResolver.java
+++ b/src/main/java/org/tudo/sse/resolution/JarResolver.java
@@ -229,10 +229,12 @@ public class JarResolver {
 
                 currentEntry = jarInputStream.getNextJarEntry();
             }
-        } catch (IOException | IllegalArgumentException | BytecodeProcessingFailedException e) {
+        } catch (Exception e) {
+            // OPAL throws some unexpected exceptions when faced with malformed JARs in the index (e.g. ArrayIndexOutOfBounds)
+            // Therefore, we catch all exceptions related to the processing of class files here, and wrap them.
             throw new JarResolutionException(e.getMessage());
         }
-            return entries;
+        return entries;
     }
 
     private DataInputStream getEntryByteStream(InputStream in) throws IOException  {

--- a/src/main/java/org/tudo/sse/resolution/PomResolver.java
+++ b/src/main/java/org/tudo/sse/resolution/PomResolver.java
@@ -322,8 +322,6 @@ public class PomResolver {
         } catch (IOException | XmlPullParserException e) {
             try { input.close(); } catch (Exception ignored) {}
             throw new PomResolutionException(e.getMessage(), identifier, e);
-        } catch (Exception x) {
-
         }
     }
 

--- a/src/main/java/org/tudo/sse/resolution/PomResolver.java
+++ b/src/main/java/org/tudo/sse/resolution/PomResolver.java
@@ -782,20 +782,33 @@ public class PomResolver {
     }
 
     private List<String> splitSets(String range) {
-        List<String> sets = new ArrayList<>();
+        List<String> ranges = new ArrayList<>();
         StringBuilder current = new StringBuilder();
-        int i = 0;
-        while(i < range.length()) {
-            while(i < range.length() && range.charAt(i) != ']' && range.charAt(i) != ')') {
-                current.append(range.charAt(i));
-                i++;
+        boolean isRangeOpen = false;
+
+        for(int i = 0; i < range.length(); i++){
+            switch(range.charAt(i)){
+                case '[':
+                case '(':
+                    isRangeOpen = true;
+                    current = new StringBuilder();
+                    current.append(range.charAt(i));
+                    break;
+                case ']':
+                case ')':
+                    current.append(range.charAt(i));
+                    isRangeOpen = false;
+                    ranges.add(current.toString());
+                    break;
+                default:
+                    // Keep anything inside a range (whitespaces, etc) as is, drop anything between ranges (commas, whitespaces)
+                    if(isRangeOpen)
+                        current.append(range.charAt(i));
+                    break;
             }
-             current.append(range.charAt(i));
-            i += 2;
-            sets.add(current.toString());
-            current = new StringBuilder();
         }
-        return sets;
+
+        return ranges;
     }
 
     private static boolean isVersionRange(String version) {

--- a/src/test/resources/PomInputs.json
+++ b/src/test/resources/PomInputs.json
@@ -362,7 +362,7 @@
       "org.springframework.boot:spring-boot-starter-web:2.5.0:compile",
       "com.fasterxml.jackson.core:jackson-databind:2.10.0:compile",
       "org.hibernate:hibernate-core:5.3.0.CR2:compile",
-      "com.google.guava:guava:33.3.1-jre:compile",
+      "com.google.guava:guava:33.4.0-jre:compile",
       "org.apache.httpcomponents:httpclient:4.5.13:compile",
       "commons-io:commons-io:2.18.0:compile"
     ]


### PR DESCRIPTION
# Problems
One of our students found multiple issues related to uncaught exceptions of type `IndexOutOfBoundsException` when using MARIN to iterate Maven Central. This PR fixes three separate such issues.

## Handling of Version Ranges
Our own implementation for splitting concatinated version ranges was flawed, and produced exceptions like the one below when parsing invalid version specifications.

```
Exception in thread "main" java.lang.StringIndexOutOfBoundsException: Index 87 out of bounds for length 87
    at java.base/jdk.internal.util.Preconditions$1.apply(Unknown Source)
    at java.base/jdk.internal.util.Preconditions$1.apply(Unknown Source)
    at java.base/jdk.internal.util.Preconditions$4.apply(Unknown Source)
    at java.base/jdk.internal.util.Preconditions$4.apply(Unknown Source)
    at java.base/jdk.internal.util.Preconditions.outOfBounds(Unknown Source)
    at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Unknown Source)
    at java.base/jdk.internal.util.Preconditions.checkIndex(Unknown Source)
    at java.base/java.lang.String.checkIndex(Unknown Source)
    at java.base/java.lang.StringLatin1.charAt(Unknown Source)
    at java.base/java.lang.String.charAt(Unknown Source)
    at org.tudo.sse.resolution.PomResolver.splitSets(PomResolver.java:788)
    at org.tudo.sse.resolution.PomResolver.resolveVersionRange(PomResolver.java:722)
    at org.tudo.sse.resolution.PomResolver.resolveDependency(PomResolver.java:501)
    at org.tudo.sse.resolution.PomResolver.resolveDependencies(PomResolver.java:462)
    at org.tudo.sse.resolution.PomResolver.resolveArtifact(PomResolver.java:235)
    at org.tudo.sse.resolution.ResolverFactory.runBoth(ResolverFactory.java:48)
    at org.tudo.sse.MavenCentralAnalysis.callResolver(MavenCentralAnalysis.java:584)
    at org.tudo.sse.MavenCentralAnalysis.processIndex(MavenCentralAnalysis.java:262)
    at org.tudo.sse.MavenCentralAnalysis.walkPaginated(MavenCentralAnalysis.java:322)
    at org.tudo.sse.MavenCentralAnalysis.indexProcessor(MavenCentralAnalysis.java:241)
    at org.tudo.sse.MavenCentralAnalysis.runAnalysis(MavenCentralAnalysis.java:210)
    at QuantitativeAnalyse.Analyse$.runMarin(Analyse.scala:112)
    at QuantitativeAnalyse.Analyse$.main(Analyse.scala:36)
    at QuantitativeAnalyse.Analyse.main(Analyse.scala) 
```

## Uncaught `ArrayIndexOutOfBoundsException` in `MavenXpp3Reader`
The library we use for parsing `pom.xml` files (`MavenXpp3Reader`) throws uncaught Exceptions when encountering malformed files, see exception below:
```
Exception in thread "main" java.lang.ArrayIndexOutOfBoundsException: Index 15428 out of bounds for length 8192
    at org.codehaus.plexus.util.xml.pull.MXParser.parsePI(MXParser.java:2470)
    at org.codehaus.plexus.util.xml.pull.MXParser.nextImpl(MXParser.java:1257)
    at org.codehaus.plexus.util.xml.pull.MXParser.next(MXParser.java:1105)
    at org.codehaus.plexus.util.xml.pull.MXParser.nextTag(MXParser.java:1090)
    at org.apache.maven.model.io.xpp3.MavenXpp3Reader.parsePluginExecution(MavenXpp3Reader.java:3105)
    at org.apache.maven.model.io.xpp3.MavenXpp3Reader.parsePlugin(MavenXpp3Reader.java:2918)
    at org.apache.maven.model.io.xpp3.MavenXpp3Reader.parsePluginManagement(MavenXpp3Reader.java:3186)
    at org.apache.maven.model.io.xpp3.MavenXpp3Reader.parseBuild(MavenXpp3Reader.java:1157)
    at org.apache.maven.model.io.xpp3.MavenXpp3Reader.parseModel(MavenXpp3Reader.java:2456)
    at org.apache.maven.model.io.xpp3.MavenXpp3Reader.read(MavenXpp3Reader.java:4088)
    at org.apache.maven.model.io.xpp3.MavenXpp3Reader.read(MavenXpp3Reader.java:4021)
    at org.apache.maven.model.io.xpp3.MavenXpp3Reader.read(MavenXpp3Reader.java:4050)
    at org.tudo.sse.resolution.PomResolver.processRawPomFeatures(PomResolver.java:255)
    at org.tudo.sse.resolution.PomResolver.processArtifact(PomResolver.java:382)
    at org.tudo.sse.resolution.PomResolver.getAllRelevantFiles(PomResolver.java:405)
    at org.tudo.sse.resolution.PomResolver.processArtifact(PomResolver.java:396)
    at org.tudo.sse.resolution.PomResolver.recursiveResolver(PomResolver.java:873)
    at org.tudo.sse.resolution.PomResolver.resolveTransitives(PomResolver.java:862)
    at org.tudo.sse.resolution.PomResolver.resolveAllTransitives(PomResolver.java:841)
    at org.tudo.sse.resolution.PomResolver.recursiveResolver(PomResolver.java:875)
    at org.tudo.sse.resolution.PomResolver.resolveTransitives(PomResolver.java:862)
    at org.tudo.sse.resolution.PomResolver.resolveAllTransitives(PomResolver.java:841)
    at org.tudo.sse.resolution.PomResolver.recursiveResolver(PomResolver.java:875)
    at org.tudo.sse.resolution.PomResolver.resolveTransitives(PomResolver.java:862)
    at org.tudo.sse.resolution.PomResolver.resolveAllTransitives(PomResolver.java:841)
    at org.tudo.sse.resolution.PomResolver.resolveArtifact(PomResolver.java:238)
    at org.tudo.sse.resolution.ResolverFactory.runBoth(ResolverFactory.java:48)
    at org.tudo.sse.MavenCentralAnalysis.callResolver(MavenCentralAnalysis.java:584)
    at org.tudo.sse.MavenCentralAnalysis.processIndex(MavenCentralAnalysis.java:262)
    at org.tudo.sse.MavenCentralAnalysis.walkPaginated(MavenCentralAnalysis.java:322)
    at org.tudo.sse.MavenCentralAnalysis.indexProcessor(MavenCentralAnalysis.java:241)
    at org.tudo.sse.MavenCentralAnalysis.runAnalysis(MavenCentralAnalysis.java:210)
    at QuantitativeAnalyse.Analyse$.runMarin(Analyse.scala:112)
    at QuantitativeAnalyse.Analyse$.main(Analyse.scala:36)
    at QuantitativeAnalyse.Analyse.main(Analyse.scala) 
```
## Uncaught `ArrayIndexOutOfBoudnsException` in OPAL
OPAL also produced an uncaught exception when parsing JAR files, see exception stack below:
```
Exception in thread "main" java.lang.ArrayIndexOutOfBoundsException: Index 8313 out of bounds for length 9
    at org.opalj.br.instructions.package$$anon$1.unboxValue(package.scala:245)
    at org.opalj.br.instructions.package$$anon$1.unboxValue(package.scala:12)
    at org.opalj.br.ObjectType$.unboxValue(Type.scala:1410)
    at org.opalj.br.ObjectType.unboxValue(Type.scala:1036)
    at org.opalj.br.instructions.ClassFileFactory$.returnAndConvertInstructions(ClassFileFactory.scala:1311)
    at org.opalj.br.instructions.ClassFileFactory$.createProxyMethodBytecode(ClassFileFactory.scala:1045)
    at org.opalj.br.instructions.ClassFileFactory$.proxyMethod(ClassFileFactory.scala:928)
    at org.opalj.br.instructions.ClassFileFactory$.Proxy(ClassFileFactory.scala:255)
    at org.opalj.br.reader.InvokedynamicRewriting.java8LambdaResolution(InvokedynamicRewriting.scala:1209)
    at org.opalj.br.reader.InvokedynamicRewriting.deferredInvokedynamicResolution(InvokedynamicRewriting.scala:234)
    at org.opalj.br.reader.InvokedynamicRewriting.deferredInvokedynamicResolution$(InvokedynamicRewriting.scala:200)
    at org.opalj.br.reader.Java8FrameworkWithInvokedynamicSupportAndCaching.deferredInvokedynamicResolution(Java8FrameworkWithInvokedynamicSupportAndCaching.scala:15)
    at org.opalj.br.reader.CachedBytecodeReaderAndBinding.$anonfun$Instructions$1(CachedBytecodeReaderAndBinding.scala:222)
    at org.opalj.bi.reader.Constant_PoolReader.$anonfun$applyDeferredActions$1(Constant_PoolReader.scala:84)
    at org.opalj.bi.reader.Constant_PoolReader.$anonfun$applyDeferredActions$1$adapted(Constant_PoolReader.scala:84)
    at scala.collection.IterableOnceOps.foreach(IterableOnce.scala:619)
    at scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:617)
    at scala.collection.AbstractIterable.foreach(Iterable.scala:935)
    at org.opalj.bi.reader.Constant_PoolReader.applyDeferredActions(Constant_PoolReader.scala:84)
    at org.opalj.bi.reader.Constant_PoolReader.applyDeferredActions$(Constant_PoolReader.scala:81)
    at org.opalj.br.reader.Java8FrameworkWithCaching.applyDeferredActions(Java8FrameworkWithCaching.scala:15)
    at org.opalj.bi.reader.ClassFileReader.ClassFile(ClassFileReader.scala:283)
    at org.opalj.bi.reader.ClassFileReader.ClassFile$(ClassFileReader.scala:233)
    at org.opalj.br.reader.Java8FrameworkWithCaching.ClassFile(Java8FrameworkWithCaching.scala:15)
    at org.tudo.sse.resolution.JarResolver.readClassesFromJarStream(JarResolver.java:219)
    at org.tudo.sse.resolution.JarResolver.parseJar(JarResolver.java:127)
    at org.tudo.sse.resolution.ResolverFactory.runBoth(ResolverFactory.java:55)
    at org.tudo.sse.MavenCentralAnalysis.callResolver(MavenCentralAnalysis.java:615)
    at org.tudo.sse.MavenCentralAnalysis.processIndex(MavenCentralAnalysis.java:295)
    at org.tudo.sse.MavenCentralAnalysis.walkPaginated(MavenCentralAnalysis.java:355)
    at org.tudo.sse.MavenCentralAnalysis.indexProcessor(MavenCentralAnalysis.java:274)
    at org.tudo.sse.MavenCentralAnalysis.runAnalysis(MavenCentralAnalysis.java:243)
    at QuantitativeAnalyse.Analyse$.runMarin(Analyse.scala:112)
    at QuantitativeAnalyse.Analyse$.main(Analyse.scala:36)
    at QuantitativeAnalyse.Analyse.main(Analyse.scala) 
```

# Solutions
I re-implemented the handling of multiple concatinated version ranges to be more forgiving towards malformed input. I further added code that catches unexpected exceptions in `MavenXpp3Reader` and OPAL, wraps them in our own exceptions and re-throws if required.