### PR TITLE
Call writeLastProcessed multiple times while running analytics

### DIFF
--- a/src/main/java/org/tudo/sse/CliInformation.java
+++ b/src/main/java/org/tudo/sse/CliInformation.java
@@ -19,6 +19,7 @@ public class CliInformation {
     private Path toOutputDirectory;
     private boolean multi;
     private int threads;
+    private int writeProcessedIndexes;
 
     public CliInformation() {
         skip = -1;
@@ -26,6 +27,7 @@ public class CliInformation {
         since = -1;
         until = -1;
         name = Paths.get("lastIndexProcessed");
+        writeProcessedIndexes = 1000;
         toCoordinates = null;
         toIndexPos = null;
         toOutputDirectory = null;
@@ -120,4 +122,8 @@ public class CliInformation {
     public void setToOutputDirectory(Path toOutputDirectory) {
         this.toOutputDirectory = toOutputDirectory;
     }
+
+    public int getWriteProcessedIndexes() { return writeProcessedIndexes; }
+
+    public void setWriteProcessedIndexes(int writeProcessedIndexes) {this.writeProcessedIndexes = writeProcessedIndexes;}
 }

--- a/src/main/java/org/tudo/sse/MavenCentralAnalysis.java
+++ b/src/main/java/org/tudo/sse/MavenCentralAnalysis.java
@@ -397,6 +397,8 @@ public abstract class MavenCentralAnalysis {
                 artifacts.add(current);
                 processIndex(current);
             }
+            if(indexIterator.getIndex() % setupInfo.getWriteProcessedIndexes() == 0)
+                writeLastProcessed(indexIterator.getIndex(), setupInfo.getName());
         }
 
         if(setupInfo.isMulti()) {
@@ -511,6 +513,8 @@ public abstract class MavenCentralAnalysis {
                 }
                 processIndexIdentifier(ident);
             }
+            if(indexIterator.getIndex() % setupInfo.getWriteProcessedIndexes() == 0)
+                writeLastProcessed(indexIterator.getIndex(), setupInfo.getName());
         }
 
         if(setupInfo.isMulti()) {

--- a/src/main/java/org/tudo/sse/MavenCentralAnalysis.java
+++ b/src/main/java/org/tudo/sse/MavenCentralAnalysis.java
@@ -319,7 +319,7 @@ public abstract class MavenCentralAnalysis {
                 }
             }
             processIndex(current);
-            if(indexIterator.getIndex() % setupInfo.getWriteProcessedIndexes() == 1)
+            if(indexIterator.getIndex() % setupInfo.getWriteProcessedIndexes() == 0)
                 writeLastProcessed(indexIterator.getIndex(), setupInfo.getName());
         }
 
@@ -355,7 +355,7 @@ public abstract class MavenCentralAnalysis {
             }
             artifacts.add(current);
             processIndex(current);
-            if(indexIterator.getIndex() % setupInfo.getWriteProcessedIndexes() == 1)
+            if(indexIterator.getIndex() % setupInfo.getWriteProcessedIndexes() == 0)
                 writeLastProcessed(indexIterator.getIndex(), setupInfo.getName());
         }
 
@@ -437,7 +437,7 @@ public abstract class MavenCentralAnalysis {
                 }
             }
             processIndexIdentifier(ident);
-            if(indexIterator.getIndex() % setupInfo.getWriteProcessedIndexes() == 1)
+            if(indexIterator.getIndex() % setupInfo.getWriteProcessedIndexes() == 0)
                 writeLastProcessed(indexIterator.getIndex(), setupInfo.getName());
         }
 
@@ -471,7 +471,7 @@ public abstract class MavenCentralAnalysis {
                 }
             }
             processIndexIdentifier(ident);
-            if(indexIterator.getIndex() % setupInfo.getWriteProcessedIndexes() == 1)
+            if(indexIterator.getIndex() % setupInfo.getWriteProcessedIndexes() == 0)
                 writeLastProcessed(indexIterator.getIndex(), setupInfo.getName());
         }
 

--- a/src/main/java/org/tudo/sse/MavenCentralAnalysis.java
+++ b/src/main/java/org/tudo/sse/MavenCentralAnalysis.java
@@ -319,6 +319,8 @@ public abstract class MavenCentralAnalysis {
                 }
             }
             processIndex(current);
+            if(indexIterator.getIndex() % setupInfo.getWriteProcessedIndexes() == 1)
+                writeLastProcessed(indexIterator.getIndex(), setupInfo.getName());
         }
 
         if(setupInfo.isMulti()) {
@@ -353,6 +355,8 @@ public abstract class MavenCentralAnalysis {
             }
             artifacts.add(current);
             processIndex(current);
+            if(indexIterator.getIndex() % setupInfo.getWriteProcessedIndexes() == 1)
+                writeLastProcessed(indexIterator.getIndex(), setupInfo.getName());
         }
 
         if(setupInfo.isMulti()) {
@@ -433,6 +437,8 @@ public abstract class MavenCentralAnalysis {
                 }
             }
             processIndexIdentifier(ident);
+            if(indexIterator.getIndex() % setupInfo.getWriteProcessedIndexes() == 1)
+                writeLastProcessed(indexIterator.getIndex(), setupInfo.getName());
         }
 
         if(setupInfo.isMulti()) {
@@ -465,6 +471,8 @@ public abstract class MavenCentralAnalysis {
                 }
             }
             processIndexIdentifier(ident);
+            if(indexIterator.getIndex() % setupInfo.getWriteProcessedIndexes() == 1)
+                writeLastProcessed(indexIterator.getIndex(), setupInfo.getName());
         }
 
         if(setupInfo.isMulti()) {

--- a/src/main/java/org/tudo/sse/model/ArtifactIdent.java
+++ b/src/main/java/org/tudo/sse/model/ArtifactIdent.java
@@ -209,4 +209,8 @@ public class ArtifactIdent {
         return Objects.hash(groupID, artifactID, version);
     }
 
+    @Override
+    public String toString() {
+        return getCoordinates();
+    }
 }


### PR DESCRIPTION
This PR adds logic to periodically call `writeLastProcessed` after processing every N analyzeArtifact runs. This prevents the application from having to start over in case of a crash. The value of N (the checkpoint interval) is configurable via `writeProcessedIndexes`. 