### PR TITLE
Add JAR file utilities to JarInformation

### DIFF
--- a/src/main/java/org/tudo/sse/model/jar/JarInformation.java
+++ b/src/main/java/org/tudo/sse/model/jar/JarInformation.java
@@ -1,16 +1,38 @@
 package org.tudo.sse.model.jar;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opalj.br.analyses.Project;
+import org.opalj.br.reader.Java17Framework$;
+import org.opalj.br.reader.Java17LibraryFramework;
+import org.opalj.br.reader.Java17LibraryFramework$;
 import org.tudo.sse.model.ArtifactIdent;
 import org.tudo.sse.model.ArtifactInformation;
+import org.tudo.sse.resolution.FileNotFoundException;
+import org.tudo.sse.utils.MavenCentralRepository;
+import scala.Tuple2;
+import scala.jdk.CollectionConverters;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.jar.JarInputStream;
 
 /**
  * This class contains all the information that is parsed during jar resolution.
  * This information contains some statistics like codesize and number of class files, as well as a map of packages, contains lists of classfiles.
  */
 public class JarInformation extends ArtifactInformation {
+
+    private static final Logger log = LogManager.getLogger(JarInformation.class);
+
     private long codesize;
     private long numClassFiles;
     private long numMethods;
@@ -120,5 +142,159 @@ public class JarInformation extends ArtifactInformation {
      */
     public void setPackages(Map<String, List<ClassFile>> packages) {
         this.packages = packages;
+    }
+
+    /**
+     * Downloads the JAR file associated with this ArtifactInformation into a temporary directory and returns the file
+     * object representing it. Note that all temporary files will be deleted once the JVM shuts down.
+     * @return The File object representing the JAR file
+     * @throws IOException If any IO errors occur
+     * @throws FileNotFoundException If no JAR file eixsts for this ArtifactInformation
+     */
+    public File getJarFile() throws IOException, FileNotFoundException {
+        String prefix = ident.getGA().replace(".","_").replace(":","__");
+        Path theFile = Files.createTempFile(prefix,".jar");
+
+        try(InputStream is = getJarFileInputStream()){
+            Files.copy(is, theFile, StandardCopyOption.REPLACE_EXISTING);
+        }
+
+        return theFile.toFile();
+    }
+
+    /**
+     * Creates and opens an InputStream to the JAR file referenced by this ArtifactInformation.
+     * @return The JAR file InputStream
+     * @throws IOException If IO errors occur while opening the stream
+     * @throws FileNotFoundException If no JAR file exists for this ArtifactInformation
+     */
+    public InputStream getJarFileInputStream() throws IOException, FileNotFoundException {
+        return MavenCentralRepository.getInstance().openJarFileInputStream(this.ident);
+    }
+
+    /**
+     * Creates and opens a JarInputStream to the JAR file referenced by this ArtifactInformation.
+     * @return The JarInputStream
+     * @throws IOException If IO errors occur while opening the stream
+     * @throws FileNotFoundException If no JAR file exists for this ArtifactInformation
+     */
+    public JarInputStream getJarInputStream() throws IOException, FileNotFoundException {
+        return getJarInputStream(this.ident);
+    }
+
+    /**
+     * Retrieves a list of all class files contained in JAR file referenced by this ArtifactInformation. The class
+     * files are returned as represented by the OPAL framework.
+     * @return List of OPAL class file representations, or null if no JAR file was found
+     * @throws IOException If reading the JAR file fails
+     * @implNote OPAL classes are not designed to be used in large scale analyses. Over time, OPAL's internal caches
+     *           will continue to claim heap space that is never freed, so eventually the program will crash with an
+     *           OutOfMemory error. There is currently no good way to avoid this, so use OPAL instances only if you
+     *           really need them.
+     */
+    public List<org.opalj.br.ClassFile> getOpalClassFileRepresentations() throws IOException {
+        return getOpalClassFileRepresentations(this.ident);
+    }
+
+    /**
+     * Retrieves all class files for the JAR referenced by this ArtifactInformation, and uses them to initialize an
+     * OPAL project instance. This instance can be used to conduct complex static program analyses.
+     * @return The OPAL project instance, or null if no JAR file was found
+     * @throws IOException If reading the JAR file fails
+     * @implNote OPAL projects are not designed to be used in large scale analyses. Over time, OPAL's internal caches
+     *           will continue to claim heap space that is never freed, so eventually the program will crash with an
+     *           OutOfMemory error. There is currently no good way to avoid this, so use project instances only if you
+     *           really need them.
+     */
+    public Project<String> getOpalProject() throws IOException {
+        try(JarInputStream jarStream = getJarInputStream()){
+            return Project.apply(Java17Framework$.MODULE$.ClassFiles(() -> jarStream).map( t -> new Tuple2<>((org.opalj.br.ClassFile)t._1, t._2)));
+        } catch(FileNotFoundException fnfx){
+            log.error("No JAR file found for {}", ident.getCoordinates(), fnfx);
+            return null;
+        }
+    }
+
+    /**
+     * Initializes an OPAL project instance for the current JAR and the given set of dependencies. This project instance
+     * can be used to conduct complex, static whole-program analyses. Dependencies will be loaded as interfaces only,
+     * meaning no actual method implementations (i.e. bytecode) will be present for analysis.
+     *
+     * @param dependencies The transitive set of dependencies to use. Can be obtained using the PomInformation instance
+     *                     for this artifact
+     * @return The OPAL project instance, or null if no main project JAR was found
+     * @throws IOException If an IO error occurs while loading the main JAR or the dependencies
+     */
+    public Project<String> getOpalProject(Set<ArtifactIdent> dependencies) throws IOException {
+        return getOpalProject(dependencies, false, true);
+    }
+
+    /**
+     * Initializes an OPAL project instance for the current JAR and the given set of dependencies. This project instance
+     * can be used to conduct complex, static whole-program analyses.
+     * @param dependencies The transitive set of dependencies to use. Can be obtained using the PomInformation instance
+     *                     for this artifact
+     * @param fullyLoadLibraries Whether to fully load the dependency's class file contents. If set to false, only their
+     *                           interface definitions (class names, method signatures) are loaded, not their actual
+     *                           content.
+     * @param breakOnFailure If set to true, any IO exception when loading dependencies interrupts the method execution
+     *                       and throws the exception up to the calling method. If set to false, dependencies will be
+     *                       loaded in a best-effort fashion, and errors will only be logged to the console.
+     * @return The OPAL project instance, or null if no main project JAR was found
+     * @throws IOException If an IO error occurs while loading the main JAR, or the dependencies (when breakOnFailure is
+     *                     enabled).
+     */
+    public Project<String> getOpalProject(Set<ArtifactIdent> dependencies, boolean fullyLoadLibraries, boolean breakOnFailure) throws IOException {
+        List<Tuple2<org.opalj.br.ClassFile, String>> allLibraryClasses = new ArrayList<>();
+
+        for(ArtifactIdent dependency : dependencies){
+            try(JarInputStream jarStream = getJarInputStream(dependency)){
+                addClassFilesToList(allLibraryClasses, jarStream, fullyLoadLibraries);
+            } catch (IOException iox){
+                log.error("Failed to obtain dependency JAR {} for project {}", dependency, ident, iox);
+                if(breakOnFailure) throw iox;
+            } catch (FileNotFoundException fnfx){
+                // Empty, there might be dependencies without a JAR
+            }
+        }
+
+        List<Tuple2<org.opalj.br.ClassFile, String>> allProjectClasses = new ArrayList<>();
+        try(JarInputStream jarStream = getJarInputStream()){
+            addClassFilesToList(allProjectClasses, jarStream, true);
+        } catch (FileNotFoundException fnfx){
+            log.error("No JAR file found for {}", ident.getCoordinates(), fnfx);
+            return null;
+        }
+
+        return Project.apply(CollectionConverters.ListHasAsScala(allProjectClasses).asScala().toSeq(),
+                CollectionConverters.ListHasAsScala(allLibraryClasses).asScala().toSeq(), !fullyLoadLibraries);
+    }
+
+    private List<org.opalj.br.ClassFile> getOpalClassFileRepresentations(ArtifactIdent ident) throws IOException {
+        List<org.opalj.br.ClassFile> opalCFs = new ArrayList<>();
+
+        try(JarInputStream jarStream = getJarInputStream(ident)){
+            Java17LibraryFramework$.MODULE$.ClassFiles(() -> jarStream)
+                    .foreach(cf -> opalCFs.add((org.opalj.br.ClassFile)cf._1));
+        } catch(FileNotFoundException fnfx){
+            return null;
+        }
+
+        return opalCFs;
+    }
+
+    private JarInputStream getJarInputStream(ArtifactIdent ident) throws IOException, FileNotFoundException {
+        return new JarInputStream(MavenCentralRepository.getInstance().openJarFileInputStream(ident));
+    }
+
+    private void addClassFilesToList(List<Tuple2<org.opalj.br.ClassFile, String>> cfList, JarInputStream jarStream, boolean loadFully){
+        Java17LibraryFramework reader = loadFully ? Java17Framework$.MODULE$ : Java17LibraryFramework$.MODULE$;
+        CollectionConverters
+                .SeqHasAsJava(reader.ClassFiles(() -> jarStream))
+                .asJava()
+                .forEach( tuple ->
+                    cfList.add(new Tuple2<>((org.opalj.br.ClassFile)tuple._1, tuple._2))
+                );
+
     }
 }

--- a/src/test/java/org/tudo/sse/model/jar/JarInformationTest.java
+++ b/src/test/java/org/tudo/sse/model/jar/JarInformationTest.java
@@ -1,0 +1,140 @@
+package org.tudo.sse.model.jar;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.opalj.br.ClassFile;
+import org.opalj.br.ObjectType;
+import org.opalj.br.analyses.Project;
+import org.tudo.sse.model.ArtifactIdent;
+
+import java.io.File;
+import java.io.InputStream;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarInputStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class JarInformationTest {
+
+    private final long expectedFileSizeBytes = 79347L;
+    private final ArtifactIdent ident = new ArtifactIdent("eu.sse-labs", "marin", "1.0.0");
+    private final JarInformation jarInfo = new JarInformation(ident);
+
+    @Test
+    @DisplayName("JAR information should be able to download file to temp directory")
+    void testLocalFile(){
+        try {
+            File tempFile = jarInfo.getJarFile();
+            assertTrue(tempFile.exists());
+            assertTrue(tempFile.canRead());
+            assertEquals(tempFile.length(), expectedFileSizeBytes);
+        } catch(Exception x) {
+            fail(x);
+        }
+    }
+
+    @Test
+    @DisplayName("JAR information should be able to open an InputStream to the actual file")
+    void testInputStream(){
+        try {
+            InputStream is = jarInfo.getJarFileInputStream();
+            byte[] jarFileBytes = is.readAllBytes();
+            is.close();
+            assertEquals(expectedFileSizeBytes, jarFileBytes.length);
+        } catch(Exception x){
+            fail(x);
+        }
+    }
+
+    @Test
+    @DisplayName("JAR information should be able to open a JarInputStream to the underlying JAR file")
+    void testJarInputStream(){
+        final String className = "org/tudo/sse/ArtifactFactory.class";
+        try {
+            JarInputStream jis = jarInfo.getJarInputStream();
+            JarEntry entry = jis.getNextJarEntry();
+            boolean classFound = false;
+
+            while(entry != null){
+                if(entry.getName().equals(className)){
+                    classFound = true;
+                    break;
+                }
+                entry = jis.getNextJarEntry();
+            }
+
+            assertTrue(classFound);
+            assertNotNull(entry);
+            assertEquals(className, entry.getName());
+            jis.close();
+        } catch (Exception x) {
+            fail(x);
+        }
+    }
+
+    @Test
+    @DisplayName("JAR information should be able to build OPAL class file representations for the underlying JAR")
+    void testOpalClassFileRepresentations(){
+        try {
+            List<ClassFile> cfs = jarInfo.getOpalClassFileRepresentations();
+            assertNotNull(cfs);
+            assertFalse(cfs.isEmpty());
+
+            boolean foundClass = false;
+
+            for(ClassFile cf : cfs){
+                if(cf.thisType().simpleName().equals("ArtifactFactory")){
+                    foundClass = true;
+                    break;
+                }
+            }
+
+            assertTrue(foundClass);
+        } catch(Exception x){
+            fail(x);
+        }
+    }
+
+    @Test
+    @DisplayName("JAR information should be able to initialize an OPAL project instance for the underlying JAR")
+    void testOpalProjectSimple(){
+        try {
+            Project<?> project = jarInfo.getOpalProject();
+            ObjectType afType = project.allProjectClassFiles().find( cf -> cf.thisType().simpleName().equals("ArtifactFactory")).get().thisType();
+            assertNotNull(afType);
+            assertTrue(project.classHierarchy().isKnown(afType));
+            assertTrue(project.allLibraryClassFiles().isEmpty());
+        } catch (Exception x) {
+            fail(x);
+        }
+    }
+
+    @Test
+    @DisplayName("JAR information should be able to initialize a complex OPAL project instance with dependencies")
+    void testOpalProjectComplex(){
+        final ArtifactIdent actualDependency = new ArtifactIdent("org.apache.maven.indexer", "indexer-reader", "7.1.3");
+        final Set<ArtifactIdent> dependencies = new HashSet<>();
+        dependencies.add(actualDependency);
+
+        try {
+            Project<?> project = jarInfo.getOpalProject(dependencies, true, true);
+
+            // Check that main project is loaded
+            ObjectType afType = project.allProjectClassFiles().find( cf -> cf.thisType().simpleName().equals("ArtifactFactory")).get().thisType();
+            assertNotNull(afType);
+            assertTrue(project.classHierarchy().isKnown(afType));
+
+            // Check that libraries are in fact loaded
+            assertFalse(project.allLibraryClassFiles().isEmpty());
+            ObjectType irType = project.allLibraryClassFiles().find(cf -> cf.thisType().simpleName().equals("IndexReader")).get().thisType();
+            assertNotNull(irType);
+            assertTrue(project.classHierarchy().isKnown(irType));
+        } catch (Exception x){
+            fail(x);
+        }
+    }
+
+}


### PR DESCRIPTION
This PR adds various utility methods to the `JarInformation` class. All of them are meant to provide convenient access to the underlying JAR file itself - the goal is to enable easy access to the JAR in case our own internal representation is not verbose enough for a given client analysis. We provide the following *views* on the underlying JAR:
* `java.io.InputStream`
* `java.util.jar.JarInputStream`
* `java.io.File` - downloads the file to the temp directory
* `List<org.opalj.br.ClassFile>` - OPAL representation of ClassFiles, which is more verbose than our own representation
* `org.opalj.br.analyses.Project` - can be instantiated either with or without dependencies. Can be used for complex whole-program analyses using OPAL.

This PR closes #20 