### PR TITLE
Update OPAL to latest 6.0.0 release

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -32,3 +32,5 @@ jobs:
       run: mvn -B compile --file pom.xml
     - name: Run unit tests
       run: mvn -B test --file pom.xml
+    - name: Update dependency graph
+      uses: advanced-security/maven-dependency-submission-action@v5

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ settings.xml
 #maven resolution files
 maven-resolution-files
 .DS_Store
+.mvn

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>de.opal-project</groupId>
             <artifactId>framework_2.13</artifactId>
-            <version>5.0.0</version>
+            <version>6.0.0</version>
         </dependency>
 
         <!-- The following dependencies are pinned (lower bound) to avoid vulnerabilities in transitive dependencies -->

--- a/src/main/java/org/tudo/sse/resolution/JarResolver.java
+++ b/src/main/java/org/tudo/sse/resolution/JarResolver.java
@@ -5,7 +5,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opalj.br.ClassFile;
 import org.opalj.br.Method;
-import org.opalj.br.ObjectType;
+import org.opalj.br.ClassType;
 import org.opalj.br.analyses.Project$;
 import org.opalj.br.package$;
 import org.opalj.br.reader.Java16LibraryFramework;
@@ -212,7 +212,7 @@ public class JarResolver {
         }
 
         if(!classFile.interfaceTypes().isEmpty()) {
-            for(ObjectType type : JavaConverters.asJava(classFile.interfaceTypes())) {
+            for(ClassType type : JavaConverters.asJava(classFile.interfaceTypes())) {
                 interfaces.add(new ObjType(type.id(), type.fqn(), type.packageName()));
             }
         }

--- a/src/test/java/org/tudo/sse/model/jar/JarInformationTest.java
+++ b/src/test/java/org/tudo/sse/model/jar/JarInformationTest.java
@@ -3,7 +3,7 @@ package org.tudo.sse.model.jar;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.opalj.br.ClassFile;
-import org.opalj.br.ObjectType;
+import org.opalj.br.ClassType;
 import org.opalj.br.analyses.Project;
 import org.tudo.sse.model.ArtifactIdent;
 
@@ -103,7 +103,7 @@ public class JarInformationTest {
     void testOpalProjectSimple(){
         try {
             Project<?> project = jarInfo.getOpalProject();
-            ObjectType afType = project.allProjectClassFiles().find( cf -> cf.thisType().simpleName().equals("ArtifactFactory")).get().thisType();
+            ClassType afType = project.allProjectClassFiles().find( cf -> cf.thisType().simpleName().equals("ArtifactFactory")).get().thisType();
             assertNotNull(afType);
             assertTrue(project.classHierarchy().isKnown(afType));
             assertTrue(project.allLibraryClassFiles().isEmpty());
@@ -123,13 +123,13 @@ public class JarInformationTest {
             Project<?> project = jarInfo.getOpalProject(dependencies, true, true);
 
             // Check that main project is loaded
-            ObjectType afType = project.allProjectClassFiles().find( cf -> cf.thisType().simpleName().equals("ArtifactFactory")).get().thisType();
+            ClassType afType = project.allProjectClassFiles().find( cf -> cf.thisType().simpleName().equals("ArtifactFactory")).get().thisType();
             assertNotNull(afType);
             assertTrue(project.classHierarchy().isKnown(afType));
 
             // Check that libraries are in fact loaded
             assertFalse(project.allLibraryClassFiles().isEmpty());
-            ObjectType irType = project.allLibraryClassFiles().find(cf -> cf.thisType().simpleName().equals("IndexReader")).get().thisType();
+            ClassType irType = project.allLibraryClassFiles().find(cf -> cf.thisType().simpleName().equals("IndexReader")).get().thisType();
             assertNotNull(irType);
             assertTrue(project.classHierarchy().isKnown(irType));
         } catch (Exception x){


### PR DESCRIPTION
As stated in #28, there is a new OPAL major release. This release supports JVM class files up to Java 25, which should greatly increase the amount of JAR files that can be parsed by MARIN without warning (up to now OPAL 5.0.0 supported class files up to Java 19).
The only API change relevant to us is that `ObjectType` has been renamed to `ClassType`.

Additionally, this PR reintroduces the upload of our dependency tree to GitHub during CI, as to (hopefully) get rid of the security warnings.

Closes #28.