### PR TITLE
Improve integration of OPAL logging output

### DIFF
--- a/src/main/java/org/tudo/sse/ArtifactFactory.java
+++ b/src/main/java/org/tudo/sse/ArtifactFactory.java
@@ -2,16 +2,25 @@ package org.tudo.sse;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import org.opalj.log.GlobalLogContext$;
+import org.opalj.log.OPALLogger;
 import org.tudo.sse.model.*;
 import org.tudo.sse.model.index.IndexInformation;
 import org.tudo.sse.model.jar.JarInformation;
 import org.tudo.sse.model.pom.PomInformation;
+import org.tudo.sse.utils.MarinOpalLogger;
 
 /**
  * The ArtifactFactory handles the creation and storage of artifacts resolved.
  * Using a map double resolutions are avoided and faster retrievals are possible.
  */
 public final class ArtifactFactory {
+
+    static {
+        // Use global OPAL Logger - will only forward OPAL messages with level error or fatal
+        OPALLogger.updateLogger(GlobalLogContext$.MODULE$, MarinOpalLogger.getGlobalLogger());
+    }
 
     private ArtifactFactory() {}
 

--- a/src/main/java/org/tudo/sse/analyses/MavenCentralAnalysis.java
+++ b/src/main/java/org/tudo/sse/analyses/MavenCentralAnalysis.java
@@ -2,6 +2,9 @@ package org.tudo.sse.analyses;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opalj.log.GlobalLogContext$;
+import org.opalj.log.OPALLogger;
+import org.tudo.sse.utils.MarinOpalLogger;
 
 abstract class MavenCentralAnalysis {
 
@@ -50,6 +53,9 @@ abstract class MavenCentralAnalysis {
             log.warn("Potential misconfiguration - analysis requires transitive information but no POM information. " +
                     "POM information will also be collected to provide transitive information.");
         }
+
+        // Use global OPAL Logger - will only forward OPAL messages with level error or fatal
+        OPALLogger.updateLogger(GlobalLogContext$.MODULE$, MarinOpalLogger.getGlobalLogger());
 
         resolveIndex = requiresIndex;
         resolvePom = requiresPom || requiresTransitives; // Cannot have transitive information without POM information

--- a/src/main/java/org/tudo/sse/model/jar/JarInformation.java
+++ b/src/main/java/org/tudo/sse/model/jar/JarInformation.java
@@ -3,15 +3,18 @@ package org.tudo.sse.model.jar;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opalj.br.analyses.Project;
+import org.opalj.br.package$;
 import org.opalj.br.reader.Java17Framework$;
 import org.opalj.br.reader.Java17LibraryFramework;
 import org.opalj.br.reader.Java17LibraryFramework$;
 import org.tudo.sse.model.ArtifactIdent;
 import org.tudo.sse.model.ArtifactInformation;
 import org.tudo.sse.resolution.FileNotFoundException;
+import org.tudo.sse.utils.MarinOpalLogger;
 import org.tudo.sse.utils.MavenCentralRepository;
 import scala.Tuple2;
 import scala.jdk.CollectionConverters;
+import scala.runtime.BoxedUnit;
 
 import java.io.File;
 import java.io.IOException;
@@ -207,8 +210,23 @@ public class JarInformation extends ArtifactInformation {
      *           really need them.
      */
     public Project<String> getOpalProject() throws IOException {
+        return getOpalProject(MarinOpalLogger.newInfoLogger(LogManager.getLogger("[OPAL-Project]")));
+    }
+
+    /**
+     * Retrieves all class files for the JAR referenced by this ArtifactInformation, and uses them to initialize an
+     * OPAL project instance. This instance can be used to conduct complex static program analyses.
+     * @return The OPAL project instance, or null if no JAR file was found
+     * @param projectLogger A custom logger instance to configure the amount of output that is produced by OPAL.
+     * @throws IOException If reading the JAR file fails
+     * @implNote OPAL projects are not designed to be used in large scale analyses. Over time, OPAL's internal caches
+     *           will continue to claim heap space that is never freed, so eventually the program will crash with an
+     *           OutOfMemory error. There is currently no good way to avoid this, so use project instances only if you
+     *           really need them.
+     */
+    public Project<String> getOpalProject(MarinOpalLogger projectLogger) throws IOException {
         try(JarInputStream jarStream = getJarInputStream()){
-            return Project.apply(Java17Framework$.MODULE$.ClassFiles(() -> jarStream).map( t -> new Tuple2<>((org.opalj.br.ClassFile)t._1, t._2)));
+            return Project.apply(Java17Framework$.MODULE$.ClassFiles(() -> jarStream).map( t -> new Tuple2<>((org.opalj.br.ClassFile)t._1, t._2)), projectLogger);
         } catch(FileNotFoundException fnfx){
             log.error("No JAR file found for {}", ident.getCoordinates(), fnfx);
             return null;
@@ -245,6 +263,28 @@ public class JarInformation extends ArtifactInformation {
      *                     enabled).
      */
     public Project<String> getOpalProject(Set<ArtifactIdent> dependencies, boolean fullyLoadLibraries, boolean breakOnFailure) throws IOException {
+        return getOpalProject(dependencies, fullyLoadLibraries, breakOnFailure,
+                MarinOpalLogger.newInfoLogger(LogManager.getLogger("[OPAL-Project]")));
+    }
+
+    /**
+     * Initializes an OPAL project instance for the current JAR and the given set of dependencies. This project instance
+     * can be used to conduct complex, static whole-program analyses.
+     * @param dependencies The transitive set of dependencies to use. Can be obtained using the PomInformation instance
+     *                     for this artifact
+     * @param fullyLoadLibraries Whether to fully load the dependency's class file contents. If set to false, only their
+     *                           interface definitions (class names, method signatures) are loaded, not their actual
+     *                           content.
+     * @param breakOnFailure If set to true, any IO exception when loading dependencies interrupts the method execution
+     *                       and throws the exception up to the calling method. If set to false, dependencies will be
+     *                       loaded in a best-effort fashion, and errors will only be logged to the console.
+     * @param projectLogger A custom logger instance to configure the amount of output that is produced by OPAL.
+     * @return The OPAL project instance, or null if no main project JAR was found
+     * @throws IOException If an IO error occurs while loading the main JAR, or the dependencies (when breakOnFailure is
+     *                     enabled).
+     */
+    public Project<String> getOpalProject(Set<ArtifactIdent> dependencies, boolean fullyLoadLibraries,
+                                          boolean breakOnFailure, MarinOpalLogger projectLogger) throws IOException {
         List<Tuple2<org.opalj.br.ClassFile, String>> allLibraryClasses = new ArrayList<>();
 
         for(ArtifactIdent dependency : dependencies){
@@ -267,7 +307,12 @@ public class JarInformation extends ArtifactInformation {
         }
 
         return Project.apply(CollectionConverters.ListHasAsScala(allProjectClasses).asScala().toSeq(),
-                CollectionConverters.ListHasAsScala(allLibraryClasses).asScala().toSeq(), !fullyLoadLibraries);
+                CollectionConverters.ListHasAsScala(allLibraryClasses).asScala().toSeq(),
+                !fullyLoadLibraries,
+                CollectionConverters.ListHasAsScala(new ArrayList<org.opalj.br.ClassFile>()).asScala().toIterable(),
+                (a, b) -> BoxedUnit.UNIT,
+                package$.MODULE$.BaseConfig(),
+                projectLogger);
     }
 
     private List<org.opalj.br.ClassFile> getOpalClassFileRepresentations(ArtifactIdent ident) throws IOException {

--- a/src/main/java/org/tudo/sse/utils/MarinOpalLogger.java
+++ b/src/main/java/org/tudo/sse/utils/MarinOpalLogger.java
@@ -1,0 +1,101 @@
+package org.tudo.sse.utils;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opalj.log.*;
+
+/**
+ * Acts as a logging bridge between Log4j and OPAL. A MarinOpalLogger instance can be passed when creating an OPAL
+ * project, and can be configured to selectively enable certain log levels. You can pass an existing Log4j logger
+ * to use as the underlying backend, otherwise the bridge will create its own Log4j logger backend.
+ */
+public class MarinOpalLogger implements OPALLogger {
+
+    private final Logger internalLog;
+    private boolean infoEnabled = true, warnEnabled = true, errorEnabled = true;
+
+    private static final MarinOpalLogger _globalInstance = newErrorOnlyLogger();
+
+    /**
+     * Create a new instance that creates a new underlying Log4j backend.
+     */
+    public MarinOpalLogger(){
+        this.internalLog = LogManager.getLogger(MarinOpalLogger.class);
+    }
+
+    /**
+     * Creates a new instance that uses the given Log4j backend.
+     * @param logger The Log4j logger to use as a backend
+     */
+    public MarinOpalLogger(Logger logger) {
+        this.internalLog = logger;
+    }
+
+    /**
+     * Sets whether the info level of OPAL shall be forwarded to the backend.
+     * @param enabled True if info level shall be forwarded, false otherwise
+     */
+    public void setInfoEnabled(boolean enabled) { this.infoEnabled = enabled; }
+    /**
+     * Sets whether the warning level of OPAL shall be forwarded to the backend.
+     * @param enabled True if warning level shall be forwarded, false otherwise
+     */
+    public void setWarnEnabled(boolean enabled) { this.warnEnabled = enabled; }
+    /**
+     * Sets whether the error level of OPAL shall be forwarded to the backend.
+     * @param enabled True if error level shall be forwarded, false otherwise
+     */
+    public void setErrorEnabled(boolean enabled) { this.errorEnabled = enabled; }
+
+    /**
+     * Creates a new logger bridge instance that only forwards error messages. Uses a new Log4j backend.
+     * @return New logger bridge instance
+     */
+    public static MarinOpalLogger newErrorOnlyLogger(){
+        MarinOpalLogger logger = new MarinOpalLogger();
+        logger.setInfoEnabled(false);
+        logger.setWarnEnabled(false);
+        logger.setErrorEnabled(true);
+        return logger;
+    }
+
+    /**
+     * Creates a new logger bridge instance that forwards info, warning and error messages. Uses the given Log4j backend.
+     * @param log The Log4j backend to use
+     * @return New logger bridge instance
+     */
+    public static MarinOpalLogger newInfoLogger(Logger log){
+        MarinOpalLogger logger = new MarinOpalLogger(log);
+        logger.setInfoEnabled(true);
+        logger.setWarnEnabled(true);
+        logger.setErrorEnabled(true);
+        return logger;
+    }
+
+    /**
+     * Gets the singleton logger bridge that is used as the OPAL global logger for MARIN.
+     * @return The global logging bridge
+     */
+    public static MarinOpalLogger getGlobalLogger(){
+        return _globalInstance;
+    }
+
+
+    @Override
+    public void log(LogMessage message, LogContext ctx) {
+        if(message.level() == Error$.MODULE$ && errorEnabled){
+            internalLog.error(message.message());
+        } else if(message.level() == Warn$.MODULE$ && warnEnabled){
+            internalLog.warn(message.message());
+        } else if(message.level() == Info$.MODULE$ && infoEnabled){
+            internalLog.info(message.message());
+        } else if(message.level() == Fatal$.MODULE$){
+            internalLog.fatal(message.message());
+        }
+    }
+
+    @Override
+    public void logOnce(LogMessage message, LogContext ctx) {
+        OPALLogger.super.logOnce(message, ctx);
+    }
+}

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -2,7 +2,7 @@
 <Configuration status="WARN">
     <Appenders>
         <Console name="LogToConsole" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n"/>
         </Console>
     </Appenders>
     <Loggers>

--- a/src/test/java/org/tudo/sse/model/jar/JarInformationTest.java
+++ b/src/test/java/org/tudo/sse/model/jar/JarInformationTest.java
@@ -1,11 +1,15 @@
 package org.tudo.sse.model.jar;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.opalj.br.ClassFile;
 import org.opalj.br.ClassType;
 import org.opalj.br.analyses.Project;
+import org.opalj.log.GlobalLogContext$;
+import org.opalj.log.OPALLogger;
 import org.tudo.sse.model.ArtifactIdent;
+import org.tudo.sse.utils.MarinOpalLogger;
 
 import java.io.File;
 import java.io.InputStream;
@@ -22,6 +26,12 @@ public class JarInformationTest {
     private final long expectedFileSizeBytes = 79347L;
     private final ArtifactIdent ident = new ArtifactIdent("eu.sse-labs", "marin", "1.0.0");
     private final JarInformation jarInfo = new JarInformation(ident);
+
+    @BeforeAll
+    static void setup(){
+        // Use global OPAL Logger - will only forward OPAL messages with level error or fatal
+        OPALLogger.updateLogger(GlobalLogContext$.MODULE$, MarinOpalLogger.getGlobalLogger());
+    }
 
     @Test
     @DisplayName("JAR information should be able to download file to temp directory")


### PR DESCRIPTION
As stated in #31, it was confusing for users to see a lot of irrelevant OPAL logging output when JAR information is requested. This PR introduces a few changes to streamline the logging experience for clients:
* Disable global OPAL logging by default, only forward log level `Error` and `Fatal` to the internal Log4J logging backend
* Provide a new class `MarinOpalLogger` that acts as a bridge between Log4j and the OPALLogger interface.
* Enhance JAR utilities provided in #26 so that they can accept a custom `MarinOpalLogger` - it is still possible to provide none, in which case a default implementation is used. This allows clients to configure which log levels they want forwarded when they explictily request the instantiation of an OPAL project.
* Disable logging of thread name, this was not very helpful and made logs harder to read.

Closes #31.