### PR TITLE
Introduce additional analysis lifecycle hooks. Fix two deprecation wa…

### DIFF
--- a/src/main/java/org/tudo/sse/analyses/MavenCentralAnalysis.java
+++ b/src/main/java/org/tudo/sse/analyses/MavenCentralAnalysis.java
@@ -63,6 +63,29 @@ abstract class MavenCentralAnalysis {
         resolveJar = requiresJar;
     }
 
+    /**
+     * Analysis lifecycle hook that is executed before the actual analysis run is started, but after command line
+     * parameters and resolvers have been initialized. This method is called exactly once per analysis run.
+     */
+    protected void beforeRunStart(){
+        log.debug("Starting Maven Central analysis run.");
+    }
+
+
+    /**
+     * Analysis lifecycle hook that is executed after the analysis run has completed, immediately before the end of
+     * {@link #runAnalysis runAnalysis}. This method is called exactly once per analysis run.
+     */
+    protected void afterRunEnd(){
+        log.debug("Finished Maven Central analysis run.");
+    }
+
+    /**
+     *  Starts a new analysis run. Will parse the given command line arguments and create a matching analysis
+     *  configuration. Depending on the arguments provided, the analysis run will use single- or multithreaded execution.
+     *
+     * @param args Command line arguments to parse - usually taken directly from the main method's arguments.
+     */
     public abstract void runAnalysis(String[] args);
 
 }

--- a/src/main/java/org/tudo/sse/analyses/MavenCentralArtifactAnalysis.java
+++ b/src/main/java/org/tudo/sse/analyses/MavenCentralArtifactAnalysis.java
@@ -101,13 +101,6 @@ public abstract class MavenCentralArtifactAnalysis extends MavenCentralAnalysis 
         }
     }
 
-    /**
-     *  This method is the driver code for the analysis being done on Maven Central.
-     *  It can be configured using different command line arguments being passed to it.
-     *  There's a single-threaded implementation contained in this class, as well as a multithreaded one called here but defined in different actor classes.
-     *
-     * @param args cli passed to the program to configure the run
-     */
     @Override
     public final void runAnalysis(String[] args)  {
         // Obtain CLI arguments
@@ -135,6 +128,14 @@ public abstract class MavenCentralArtifactAnalysis extends MavenCentralAnalysis 
                     artifactConfig.progressWriteInterval, artifactConfig.progressOutputFile), "queueActor");
         }
 
+        // Invoke the beforeRunStart lifecycle hook
+        try {
+            this.beforeRunStart();
+        } catch (Exception x){
+            log.error("Unexpected exception in analysis lifecycle hook beforeRunStart", x);
+            return;
+        }
+
         if(this.artifactConfig.inputListFile == null) {
             indexProcessor();
         } else {
@@ -147,6 +148,13 @@ public abstract class MavenCentralArtifactAnalysis extends MavenCentralAnalysis 
                 this.queueActorRef.tell(WorkloadIsFinalMessage.getInstance(), ActorRef.noSender());
                 system.getWhenTerminated().toCompletableFuture().get();
             } catch (Exception x) { log.warn("Error closing actor system: {}", x.getMessage());}
+        }
+
+        // Invoke the afterRunEnd lifecycle hook
+        try {
+            this.afterRunEnd();
+        } catch(Exception x){
+            log.error("Unexpected exception in analysis lifecycle hook afterRunEnd", x);
         }
     }
 
@@ -192,12 +200,10 @@ public abstract class MavenCentralArtifactAnalysis extends MavenCentralAnalysis 
      * Iterates over all indexes in the maven central index and creates an artifact with the metadata collected.
      *
      * @param indexIterator an iterator for traversing the maven central index
-     * @return a list of artifact identifiers processed by this method
      * @see ArtifactIdent
      * @throws IOException when there is an issue opening a file
      */
-    List<ArtifactIdent> walkAllIndexes(IndexIterator indexIterator) throws IOException {
-        final List<ArtifactIdent> artifactIdents = new ArrayList<>();
+    private void walkAllIndexes(IndexIterator indexIterator) throws IOException {
         long entriesTaken = 0L;
 
         while(indexIterator.hasNext()) {
@@ -219,8 +225,6 @@ public abstract class MavenCentralArtifactAnalysis extends MavenCentralAnalysis 
                 processIndexIdentifier(current.getIdent());
             }
 
-            artifactIdents.add(current.getIdent());
-
             writePositionIfNeeded();
         }
 
@@ -230,7 +234,6 @@ public abstract class MavenCentralArtifactAnalysis extends MavenCentralAnalysis 
             log.info("Processed a total of {} entries.", entriesTaken);
 
         indexIterator.closeReader();
-        return artifactIdents;
     }
 
     /**

--- a/src/main/java/org/tudo/sse/analyses/MavenCentralLibraryAnalysis.java
+++ b/src/main/java/org/tudo/sse/analyses/MavenCentralLibraryAnalysis.java
@@ -105,6 +105,14 @@ public abstract class MavenCentralLibraryAnalysis extends MavenCentralAnalysis {
         if(config.take >= 0)
             log.info("Taking {} library names", config.take);
 
+        // Invoke the beforeRunStart lifecycle hook
+        try {
+            this.beforeRunStart();
+        } catch (Exception x){
+            log.error("Unexpected exception in analysis lifecycle hook beforeRunStart", x);
+            return;
+        }
+
         // If specified, we only take the configured amount of entries. If not, we process as long as the iterator
         // provides new entries
         while((config.take < 0 || entriesTaken < config.take) && gaIterator.hasNext()){
@@ -138,7 +146,52 @@ public abstract class MavenCentralLibraryAnalysis extends MavenCentralAnalysis {
                 system.getWhenTerminated().toCompletableFuture().get();
             } catch (Exception x) { log.warn("Error closing actor system: {}", x.getMessage());}
         }
+
+        // Invoke the afterRunEnd lifecycle hook
+        try {
+            this.afterRunEnd();
+        } catch(Exception x){
+            log.error("Unexpected exception in analysis lifecycle hook afterRunEnd", x);
+        }
     }
+
+    /**
+     * Analysis lifecycle hook that is executed before a library is being processed, i.e., before any releases are
+     * discovered.
+     *
+     * @implNote This method may be called concurrently by multiple threads if the analysis uses parallel execution
+     *
+     * @param groupId The library's group ID
+     * @param artifactId The library's artifact ID
+     */
+    protected void beforeLibraryStart(String groupId, String artifactId) {
+        log.debug("Start processing library {}:{}", groupId, artifactId);
+    }
+
+    /**
+     * Analysis lifecycle hook that is executed after a library has been processed, i.e., after all releases have been
+     * discovered and the analysis implementation has been executed.
+     *
+     * @implNote This method may be called concurrently by multiple threads if the analysis uses parallel execution
+     *
+     * @param groupId The library's group ID
+     * @param artifactId The library's artifact ID
+     * @param artifacts The set of artifacts for the given library
+     */
+    protected void afterLibraryEnd(String groupId, String artifactId, List<Artifact> artifacts) {
+        log.debug("Finished processing {} artifacts for library {}:{}", artifacts.size(), groupId, artifactId);
+    }
+
+    /**
+     * Analysis lifecycle hook that is executed when the analysis failed to obtain a version list for a given library.
+     *
+     * @implNote This method may be called concurrently by multiple threads if the analysis uses parallel execution
+     *
+     * @param groupId The library's group ID
+     * @param artifactId The library's artifact ID
+     * @param cause The exception that caused the failure
+     */
+    protected void onVersionListError(String groupId, String artifactId, Exception cause){}
 
     /**
      * Main analysis implementation. Defines how a single library shall be analyzed. All artifacts for a given
@@ -168,6 +221,12 @@ public abstract class MavenCentralLibraryAnalysis extends MavenCentralAnalysis {
     }
 
     private Void process(String ga, String groupId, String artifactId){
+
+        try { this.beforeLibraryStart(groupId, artifactId); }
+        catch(Exception x){
+            log.error("Unexpected exception in analysis lifecycle hook beforeLibraryStart for library {}, {}", groupId, artifactId, x);
+        }
+
         List<ArtifactIdent> identifiers = getReleaseIdentifiers(groupId, artifactId);
 
         // Abort if we find no releases, error has already been logged at this point
@@ -189,6 +248,11 @@ public abstract class MavenCentralLibraryAnalysis extends MavenCentralAnalysis {
             log.error("Unknown error in analysis implementation", x);
         }
 
+        try { this.afterLibraryEnd(groupId, artifactId, libraryArtifacts); }
+        catch(Exception x){
+            log.error("Unexpected exception in analysis lifecycle hook afterLibraryEnd for library {}, {}", groupId, artifactId, x);
+        }
+
         return null;
     }
 
@@ -202,6 +266,12 @@ public abstract class MavenCentralLibraryAnalysis extends MavenCentralAnalysis {
             return identifiers;
         } catch (Exception x) {
             log.warn("Failed to obtain version list for library {}:{}", groupId, artifactId, x);
+
+            try { this.onVersionListError(groupId, artifactId, x); }
+            catch(Exception inner) {
+                log.warn("Unexcepted exception in analysis lifecycle hook onVersionListError for library {}:{}, {}", groupId, artifactId, x);
+            }
+
             return null;
         }
     }

--- a/src/main/java/org/tudo/sse/model/jar/JarInformation.java
+++ b/src/main/java/org/tudo/sse/model/jar/JarInformation.java
@@ -309,7 +309,7 @@ public class JarInformation extends ArtifactInformation {
         return Project.apply(CollectionConverters.ListHasAsScala(allProjectClasses).asScala().toSeq(),
                 CollectionConverters.ListHasAsScala(allLibraryClasses).asScala().toSeq(),
                 !fullyLoadLibraries,
-                CollectionConverters.ListHasAsScala(new ArrayList<org.opalj.br.ClassFile>()).asScala().toIterable(),
+                CollectionConverters.ListHasAsScala(new ArrayList<org.opalj.br.ClassFile>()).asScala().toSeq(),
                 (a, b) -> BoxedUnit.UNIT,
                 package$.MODULE$.BaseConfig(),
                 projectLogger);

--- a/src/main/java/org/tudo/sse/resolution/JarResolver.java
+++ b/src/main/java/org/tudo/sse/resolution/JarResolver.java
@@ -168,7 +168,7 @@ public class JarResolver {
             numMethods += current.methods().size();
             numFields += current.fields().size();
 
-            List<Method> methods =  JavaConverters.seqAsJavaList(classfile._1.methods());
+            List<Method> methods =  scala.jdk.CollectionConverters.SeqHasAsJava(classfile._1.methods()).asJava();
             for(Method method : methods) {
                 //tally up bytecode for each method here
                 if(method.body().isDefined()) {

--- a/src/test/java/org/tudo/sse/resolution/PomResolverTest.java
+++ b/src/test/java/org/tudo/sse/resolution/PomResolverTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.tudo.sse.IndexWalker;
 import org.tudo.sse.model.*;
 
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.io.*;
@@ -59,7 +60,7 @@ class PomResolverTest {
         for(String input : inputs) {
             RawPomFeatures current = null;
             try {
-                current = pomResolver.processRawPomFeatures(IOUtils.toInputStream(input), null);
+                current = pomResolver.processRawPomFeatures(IOUtils.toInputStream(input, StandardCharsets.UTF_8), null);
             } catch (PomResolutionException e) {
                 fail(e);
             }


### PR DESCRIPTION
This PR introduces some additional analysis lifecycle hooks, as described in #19. The following hooks have been implemented:
* `beforeRunStart` Will be executed right before an analysis run starts - at this point the configuration has already been parsed and resolvers have been initialized. Valid for both analysis types.
* `afterRunEnd` Will be executed after a run has finished execution, right before `runAnalysis` ends. Valid for both analysis types
* `beforeLibraryStart` Is invoked before a library is being processed in the `MavenCentralLibraryAnalysis` - no version list has been loaded at this point. Is given the library name.
* `afterLibraryEnd` Is invoked after a library has been processed - is given the library name and all artifacts.
* `onVersionListError` Is invoked when the `MavenCentralLibraryAnalysis` failed to obtain a version list for a given library. Is given the library name and the exception that cause the error.

All hooks are being executed within a `try` block that catches all exceptions and logs them - so no error in client-defined code will crash execution. This PR also fixes three deprecation warnings and removes one unused return value.

Closes #19.