### PR TITLE
Introduce Linter warnings to Maven build process, fix resulting code style issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,8 +37,7 @@
     </scm>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>
@@ -134,6 +133,16 @@
                     <includes>
                         <include>**/*Test.java</include>
                     </includes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.14.1</version>
+                <configuration>
+                    <compilerArgs>
+                        <arg>-Xlint:all,-serial</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/org/tudo/sse/model/pom/LocalPomInformation.java
+++ b/src/main/java/org/tudo/sse/model/pom/LocalPomInformation.java
@@ -20,45 +20,55 @@ import java.util.Map;
  */
 public class LocalPomInformation extends PomInformation {
 
-    private Path pomPath;
+    private final Path pomPath;
+    private final boolean loadTransitives;
+    private final InputStream pomStream;
+
 
     /**
      * Creates a new LocalPomInformation object for a POM file located at the given path.
      *
-     * @param path The Path object identifying a pom file
-     * @param resolver The PomResolver to use for resolution
-     * @throws FileNotFoundException If the given Path does not exist
+     * @param pomPath The Path object identifying a pom file
+     * @param loadTransitives Whether to load transitive pom information upon initialization
      */
-    public LocalPomInformation(String path, PomResolver resolver) throws FileNotFoundException {
-        this(new FileInputStream(path), resolver);
-        this.pomPath = Paths.get(path);
+    public LocalPomInformation(Path pomPath, boolean loadTransitives){
+        this.pomPath = pomPath;
+        this.loadTransitives = loadTransitives;
+        this.pomStream = null;
     }
 
     /**
-     * Creates a new LocalPomInformation object for a given POM file
-     * @param localPom The file object identifying the local POM file
-     * @param resolver The PomResolver to use for resolution
-     * @throws FileNotFoundException If the given File does not exist
+     * Creates a new LocalPomInformation object for a pom file input stream without a file path on the current drive.
+     * @param pomStream Input Stream containing pom file contents
+     * @param loadTransitives Whether to load transitive pom information upon initialization
      */
-    public LocalPomInformation(File localPom, PomResolver resolver) throws FileNotFoundException{
-        this(new FileInputStream(localPom), resolver);
-        this.pomPath = localPom.toPath();
+    public LocalPomInformation(InputStream pomStream, boolean loadTransitives){
+        this.pomPath = null;
+        this.loadTransitives = loadTransitives;
+        this.pomStream = pomStream;
     }
 
     /**
-     * Creates a new LocalPomInformation object for a given InputStream (representing a text file).
-     * @param localPom An InputStream containing the POM file contents
-     * @param resolver The PomResolver to use for resolution
+     * Resolve the local pom file and compute all information as specified upon object creation.
+     *
+     * @param resolver The pom resolver to use for resolution
+     * @throws IOException If reading the pom file contents fails
+     * @throws XmlPullParserException If parsing the pom.xml file fails
      */
-    public LocalPomInformation(InputStream localPom, PomResolver resolver) {
-        super();
-        try {
-            resolveLocalFile(resolver, localPom);
+    public void resolveLocalPom(PomResolver resolver) throws IOException, XmlPullParserException {
+        if(pomStream != null) {
+            resolveLocalFile(resolver, this.pomStream);
+        } else {
+            try (FileInputStream is = new FileInputStream(this.pomPath.toFile())) {
+                resolveLocalFile(resolver, is);
+            }
+        }
+
+        if(this.loadTransitives){
             resolveParentAndImport(resolver);
             resolveDependencies(resolver);
-        } catch (IOException | XmlPullParserException e) {
-            throw new RuntimeException(e);
         }
+
     }
 
     /**
@@ -78,7 +88,7 @@ public class LocalPomInformation extends PomInformation {
      * @throws IOException when there's an issue opening the file
      * @throws XmlPullParserException when there's an issue parsing the local file using the maven model
      */
-    public void resolveLocalFile(PomResolver resolver, InputStream pomFile) throws IOException, XmlPullParserException{
+    private void resolveLocalFile(PomResolver resolver, InputStream pomFile) throws IOException, XmlPullParserException{
         MavenXpp3Reader reader = new MavenXpp3Reader();
 
         Model model = reader.read(pomFile, true);
@@ -97,8 +107,8 @@ public class LocalPomInformation extends PomInformation {
             throw new NullPointerException();
         }
 
-        setIdent(new ArtifactIdent(groupId, model.getArtifactId(), version));
-        setRawPomFeatures(processRawPomFeatures(model, resolver));
+        this.ident = new ArtifactIdent(groupId, model.getArtifactId(), version);
+        this.rawPomFeatures = processRawPomFeatures(model, resolver);
     }
 
     /**
@@ -108,7 +118,7 @@ public class LocalPomInformation extends PomInformation {
      * @param resolver pom resolver to aid in feature collection
      * @return raw features that are collected during resolution
      */
-    public RawPomFeatures processRawPomFeatures(Model model, PomResolver resolver) {
+    private RawPomFeatures processRawPomFeatures(Model model, PomResolver resolver) {
         RawPomFeatures rawPomFeatures = new RawPomFeatures();
 
         //parent information
@@ -157,18 +167,18 @@ public class LocalPomInformation extends PomInformation {
      * @see PomResolver
      * @param resolver the resolver used to resolve the parents and imports of the local pom
      */
-    public void resolveParentAndImport(PomResolver resolver) {
-        if(getRawPomFeatures().getParent() != null) {
+    private void resolveParentAndImport(PomResolver resolver) {
+        if(this.rawPomFeatures.getParent() != null) {
             try {
-                setParent(resolver.processArtifact(getRawPomFeatures().getParent()));
+                this.parent = resolver.processArtifact(this.rawPomFeatures.getParent());
             } catch (PomResolutionException | org.tudo.sse.resolution.FileNotFoundException | IOException e) {
                 throw new RuntimeException(e);
             }
         }
 
-        if(getRawPomFeatures().getDependencyManagement() != null) {
+        if(this.rawPomFeatures.getDependencyManagement() != null) {
             try {
-                setImports(resolver.resolveImports(getRawPomFeatures().getDependencyManagement(), this));
+                this.imports = resolver.resolveImports(this.rawPomFeatures.getDependencyManagement(), this);
             } catch (PomResolutionException | org.tudo.sse.resolution.FileNotFoundException | IOException e) {
                 throw new RuntimeException(e);
             }
@@ -181,7 +191,7 @@ public class LocalPomInformation extends PomInformation {
      * @see PomResolver
      * @param resolver the pomResolver used to drive this method
      */
-    public void resolveDependencies(PomResolver resolver) {
+    private void resolveDependencies(PomResolver resolver) {
         setResolvedDependencies(resolver.resolveDependencies(this));
     }
 

--- a/src/main/java/org/tudo/sse/model/pom/PomInformation.java
+++ b/src/main/java/org/tudo/sse/model/pom/PomInformation.java
@@ -9,9 +9,9 @@ import java.util.Map;
  * This class is where all the information collected during pom resolution is stored. From the raw features to resolved transitive dependencies.
  */
 public class PomInformation extends ArtifactInformation {
-    private RawPomFeatures rawPomFeatures;
-    private List<Artifact> imports;
-    private Artifact parent;
+    protected RawPomFeatures rawPomFeatures;
+    protected List<Artifact> imports;
+    protected Artifact parent;
     private List<Dependency> resolvedDependencies;
     private List<Artifact> allTransitiveDependencies;
     private List<Artifact> effectiveTransitiveDependencies;
@@ -46,7 +46,7 @@ public class PomInformation extends ArtifactInformation {
      * Updates the value of the current rawPomFeatures.
      * @param rawPomFeatures new rawPomFeatures to set
      */
-    public void setRawPomFeatures(RawPomFeatures rawPomFeatures) {
+    public final void setRawPomFeatures(RawPomFeatures rawPomFeatures) {
         this.rawPomFeatures = rawPomFeatures;
     }
 

--- a/src/main/java/org/tudo/sse/resolution/LocalPomInformationFactory.java
+++ b/src/main/java/org/tudo/sse/resolution/LocalPomInformationFactory.java
@@ -1,0 +1,126 @@
+package org.tudo.sse.resolution;
+
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.tudo.sse.model.pom.LocalPomInformation;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+
+/**
+ * Class providing static utility methods to build LocalPomFileInformation for pom.xml files not hosted on any repository.
+ */
+public class LocalPomInformationFactory {
+
+    private static final PomResolver defaultTransitiveResolver = new PomResolver(true);
+    private static final PomResolver defaultDirectResolver = new PomResolver(false);
+
+    private LocalPomInformationFactory() {}
+
+    /**
+     * Load a local pom.xml file from the given input stream, using the given resolver and resolution mode.
+     *
+     * @param pomInputStream InputStream containing the pom.xml file contents
+     * @param loadTransitiveDependencies Whether to transitively load all referenced pom files
+     * @param theResolver PomResolver to used for resolution
+     * @return LocalPomInformation object representing the pom.xml file
+     * @throws IOException If accessing the stream fails
+     */
+    public static LocalPomInformation loadLocalPom(InputStream pomInputStream,
+                                                   boolean loadTransitiveDependencies,
+                                                   PomResolver theResolver) throws IOException {
+        final LocalPomInformation pomInfo = new LocalPomInformation(pomInputStream, loadTransitiveDependencies);
+
+        try {
+            pomInfo.resolveLocalPom(theResolver);
+            return pomInfo;
+        } catch (XmlPullParserException xppx){
+            throw new RuntimeException(xppx);
+        }
+    }
+
+    /**
+     * Load a local pom.xml file from the given input stream, using the given resolution mode and a default resolver.
+     *
+     * @param pomInputStream InputStream containing the pom.xml file contents
+     * @param loadTransitiveDependencies Whether to transitively load all referenced pom files
+     * @return LocalPomInformation object representing the pom.xml file
+     * @throws IOException If accessing the stream fails
+     */
+    public static LocalPomInformation loadLocalPom(InputStream pomInputStream,
+                                                   boolean loadTransitiveDependencies) throws IOException {
+        return loadLocalPom(pomInputStream, loadTransitiveDependencies, getDefaultResolver(loadTransitiveDependencies));
+    }
+
+    /**
+     * Load a local pom.xml file from the given path, using the given resolver and resolution mode.
+     *
+     * @param pomPath Local path to pom.xml file
+     * @param loadTransitiveDependencies Whether to transitively load all referenced pom files
+     * @param theResolver PomResolver to used for resolution
+     * @return LocalPomInformation object representing the pom.xml file
+     * @throws IOException If accessing the file contents fails
+     */
+    public static LocalPomInformation loadLocalPom(Path pomPath,
+                                                   boolean loadTransitiveDependencies,
+                                                   PomResolver theResolver) throws IOException {
+        final LocalPomInformation pomInfo = new LocalPomInformation(pomPath, loadTransitiveDependencies);
+
+        try {
+            pomInfo.resolveLocalPom(theResolver);
+            return pomInfo;
+        } catch (XmlPullParserException xppx){
+            throw new RuntimeException(xppx);
+        }
+    }
+
+    /**
+     * Load a local pom.xml file from the given path, using the given resolution mode and a default resolver.
+     *
+     * @param pomPath Local path to pom.xml file
+     * @param loadTransitiveDependencies Whether to transitively load all referenced pom files
+     * @return LocalPomInformation object representing the pom.xml file
+     * @throws IOException If accessing the file contents fails
+     */
+    public static LocalPomInformation loadLocalPom(Path pomPath,
+                                                   boolean loadTransitiveDependencies) throws IOException {
+        return loadLocalPom(pomPath, loadTransitiveDependencies, getDefaultResolver(loadTransitiveDependencies));
+    }
+
+    /**
+     * Load a local pom.xml file from the given File, using the given resolver and resolution mode.
+     *
+     * @param pomFile File object representing a pom.xml file
+     * @param loadTransitiveDependencies Whether to transitively load all referenced pom files
+     * @param theResolver PomResolver to used for resolution
+     * @return LocalPomInformation object representing the pom.xml file
+     * @throws IOException If accessing the file contents fails
+     */
+    public static LocalPomInformation loadLocalPom(File pomFile,
+                                                   boolean loadTransitiveDependencies,
+                                                   PomResolver theResolver) throws IOException {
+        return loadLocalPom(pomFile.toPath(), loadTransitiveDependencies, theResolver);
+    }
+
+    /**
+     * Load a local pom.xml file from the given File, using the given resolution mode and a default resolver.
+     *
+     * @param pomFile File object representing a pom.xml file
+     * @param loadTransitiveDependencies Whether to transitively load all referenced pom files
+     * @return LocalPomInformation object representing the pom.xml file
+     * @throws IOException If accessing the file contents fails
+     */
+    public static LocalPomInformation loadLocalPom(File pomFile,
+                                                   boolean loadTransitiveDependencies) throws IOException {
+        return loadLocalPom(pomFile.toPath(), loadTransitiveDependencies, getDefaultResolver(loadTransitiveDependencies));
+    }
+
+    private static PomResolver getDefaultResolver(boolean loadTransitives){
+        if(loadTransitives)
+            return defaultTransitiveResolver;
+        else
+            return defaultDirectResolver;
+    }
+
+}

--- a/src/main/java/org/tudo/sse/resolution/PomResolver.java
+++ b/src/main/java/org/tudo/sse/resolution/PomResolver.java
@@ -671,7 +671,7 @@ public class PomResolver {
         return toReturn;
     }
 
-    private Tuple2 findGA(String missing, List<org.tudo.sse.model.pom.Dependency> management) {
+    private Tuple2<String, String> findGA(String missing, List<org.tudo.sse.model.pom.Dependency> management) {
         for (org.tudo.sse.model.pom.Dependency dependency : management) {
             if (missing.equals(dependency.getIdent().getGroupID() + ":" + dependency.getIdent().getArtifactID())) {
                 if(dependency.getScope() != null) {

--- a/src/main/java/org/tudo/sse/utils/LibraryIndexIterator.java
+++ b/src/main/java/org/tudo/sse/utils/LibraryIndexIterator.java
@@ -1,5 +1,8 @@
 package org.tudo.sse.utils;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import org.apache.maven.index.reader.ChunkReader;
 import org.apache.maven.index.reader.IndexReader;
 
@@ -11,6 +14,8 @@ import java.util.Map;
 import java.util.Set;
 
 public class LibraryIndexIterator implements Iterator<String>, AutoCloseable {
+
+    private final Logger logger = LogManager.getLogger(getClass());
 
     private final Set<Integer> libraryHashesSeen;
     private final Iterator<Map<String, String>> entryIterator;
@@ -134,12 +139,18 @@ public class LibraryIndexIterator implements Iterator<String>, AutoCloseable {
 
 
     @Override
-    public void close() throws Exception {
-        if(this.mavenChunkReader != null){
-            this.mavenChunkReader.close();
+    public void close(){
+        try {
+            if(this.mavenChunkReader != null){
+                this.mavenChunkReader.close();
+            }
+            if(this.mavenIndexReader != null) {
+                this.mavenIndexReader.close();
+            }
+        } catch(IOException iox){
+            logger.warn("Exception while closing maven index reader", iox);
         }
-        if(this.mavenIndexReader != null) {
-            this.mavenIndexReader.close();
-        }
+
+
     }
 }

--- a/src/test/java/org/tudo/sse/IndexWalkerTest.java
+++ b/src/test/java/org/tudo/sse/IndexWalkerTest.java
@@ -18,6 +18,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+@SuppressWarnings("unchecked")
 class IndexWalkerTest {
 
     IndexWalker indexWalker;

--- a/src/test/java/org/tudo/sse/analyses/MavenCentralArtifactAnalysisTest.java
+++ b/src/test/java/org/tudo/sse/analyses/MavenCentralArtifactAnalysisTest.java
@@ -26,6 +26,7 @@ import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+@SuppressWarnings("unchecked")
 class MavenCentralArtifactAnalysisTest {
     final MavenCentralArtifactAnalysis analysisUnderTest = MavenCentralAnalysisFactory.buildEmptyAnalysisWithIndexRequirement();
     final String base = "https://repo1.maven.org/maven2/";
@@ -160,9 +161,9 @@ class MavenCentralArtifactAnalysisTest {
         inputs.add(new Tuple2<>(50000, 100));
         inputs.add(new Tuple2<>(763, 20));
 
-        for(Tuple2 input : inputs) {
-            int start1 = (int) input._1;
-            int take = (int) input._2;
+        for(Tuple2<Integer, Integer> input : inputs) {
+            int start1 = input._1;
+            int take = input._2;
 
             int start2 = (start1 + take) - 1;
 

--- a/src/test/java/org/tudo/sse/model/LocalPomInformationTest.java
+++ b/src/test/java/org/tudo/sse/model/LocalPomInformationTest.java
@@ -6,10 +6,12 @@ import org.junit.jupiter.api.Test;
 import org.tudo.sse.model.pom.Dependency;
 import org.tudo.sse.model.pom.LocalPomInformation;
 import org.tudo.sse.model.pom.RawPomFeatures;
+import org.tudo.sse.resolution.LocalPomInformationFactory;
 import org.tudo.sse.resolution.PomResolver;
 import org.tudo.sse.resolution.releases.IReleaseListProvider;
 
 import java.io.*;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -17,6 +19,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+@SuppressWarnings("unchecked")
 class LocalPomInformationTest {
 
     final Gson gson = new Gson();
@@ -30,7 +33,7 @@ class LocalPomInformationTest {
 
     final IReleaseListProvider mockProvider = new IReleaseListProvider() {
 
-        private Map<String, List<String>> releaseListData = new HashMap<>();
+        private final Map<String, List<String>> releaseListData = new HashMap<>();
 
         private void buildMap(){
             for(Map<String, Object> entry : (List<Map<String, Object>>)json.get("versionLists")){
@@ -66,11 +69,11 @@ class LocalPomInformationTest {
         PomResolver resolver = new PomResolver(true, mockProvider);
 
         try {
-            tests.add(new LocalPomInformation("src/test/resources/localPom.xml", resolver));
-            tests.add(new LocalPomInformation(new File("src/test/resources/localPom.xml"), resolver));
-            tests.add(new LocalPomInformation(new FileInputStream("src/test/resources/localPom.xml"), resolver));
-        } catch (FileNotFoundException e) {
-            throw new RuntimeException(e);
+            tests.add(LocalPomInformationFactory.loadLocalPom(Path.of("src/test/resources/localPom.xml"), true, resolver));
+            tests.add(LocalPomInformationFactory.loadLocalPom(new File("src/test/resources/localPom.xml"), true, resolver));
+            tests.add(LocalPomInformationFactory.loadLocalPom(new FileInputStream("src/test/resources/localPom.xml"), true, resolver));
+        } catch (IOException iox) {
+            throw new RuntimeException(iox);
         }
 
         testFeatureExtraction(tests);
@@ -80,9 +83,12 @@ class LocalPomInformationTest {
     @Test
     void localPomException() {
         PomResolver resolver = new PomResolver(true, mockProvider);
-        assertThrows(RuntimeException.class, () -> new LocalPomInformation("src/test/resources/brokenlocalPom.xml", resolver));
-        assertThrows(RuntimeException.class, () -> new LocalPomInformation(new File("src/test/resources/brokenlocalPom.xml"), resolver));
-        assertThrows(RuntimeException.class, () -> new LocalPomInformation(new FileInputStream("src/test/resources/brokenlocalPom.xml"), resolver));
+        assertThrows(RuntimeException.class, () ->
+                LocalPomInformationFactory.loadLocalPom(Path.of("src/test/resources/brokenlocalPom.xml"), true, resolver));
+        assertThrows(RuntimeException.class, () ->
+                LocalPomInformationFactory.loadLocalPom(new File("src/test/resources/brokenlocalPom.xml"), true, resolver));
+        assertThrows(RuntimeException.class, () ->
+                LocalPomInformationFactory.loadLocalPom(new FileInputStream("src/test/resources/brokenlocalPom.xml"), true, resolver));
     }
 
     void testFeatureExtraction(List<LocalPomInformation> tests) {

--- a/src/test/java/org/tudo/sse/model/TypeStructureTest.java
+++ b/src/test/java/org/tudo/sse/model/TypeStructureTest.java
@@ -19,7 +19,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-
+@SuppressWarnings("unchecked")
 class TypeStructureTest {
 
     JarResolver resolver = new JarResolver();

--- a/src/test/java/org/tudo/sse/resolution/JarResolverTest.java
+++ b/src/test/java/org/tudo/sse/resolution/JarResolverTest.java
@@ -16,6 +16,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+@SuppressWarnings("unchecked")
 class JarResolverTest {
 
     JarResolver jarResolver;

--- a/src/test/java/org/tudo/sse/resolution/PomResolverTest.java
+++ b/src/test/java/org/tudo/sse/resolution/PomResolverTest.java
@@ -29,7 +29,7 @@ import org.tudo.sse.resolution.releases.IReleaseListProvider;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@SuppressWarnings("ALL")
+@SuppressWarnings("unchecked")
 class PomResolverTest {
 
     PomResolver pomResolver;

--- a/src/test/java/org/tudo/sse/utils/IndexIteratorTest.java
+++ b/src/test/java/org/tudo/sse/utils/IndexIteratorTest.java
@@ -14,6 +14,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+@SuppressWarnings("unchecked")
 class IndexIteratorTest {
 
     IndexIterator indexIterator;


### PR DESCRIPTION
This PR enables the `Xlint:all,-serial` compiler option via Maven. This prints all linter warnings during the Maven build process (with the exception of serialization / serialversionuid issues). It also fixes some issues as a result of this change. For tests I suppressed unchecked warnings, since they use one big JSON that is parsed into different types, making proper type checks relatively complicated.

Going forward, we should make sure to address all Linter warnings in non-test code.