### PR TITLE
Make build fail on Warnings and Incomplete JavaDoc

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -32,5 +32,7 @@ jobs:
       run: mvn -B compile --file pom.xml
     - name: Run unit tests
       run: mvn -B test --file pom.xml
+    - name: Generate JavaDoc
+      run: mvn -B javadoc:javadoc --file pom.xml
     - name: Update dependency graph
       uses: advanced-security/maven-dependency-submission-action@v5

--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,24 @@
                 <configuration>
                     <compilerArgs>
                         <arg>-Xlint:all,-serial</arg>
+                        <arg>-Werror</arg>
                     </compilerArgs>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.12.0</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <failOnWarnings>true</failOnWarnings>
                 </configuration>
             </plugin>
         </plugins>
@@ -163,19 +180,6 @@
                                 <id>attach-sources</id>
                                 <goals>
                                     <goal>jar-no-fork</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.11.2</version>
-                        <executions>
-                            <execution>
-                                <id>attach-sources</id>
-                                <goals>
-                                    <goal>jar</goal>
                                 </goals>
                             </execution>
                         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
                 <version>3.14.1</version>
                 <configuration>
                     <compilerArgs>
-                        <arg>-Xlint:all,-serial</arg>
+                        <arg>-Xlint:all,-serial,-processing</arg>
                         <arg>-Werror</arg>
                     </compilerArgs>
                 </configuration>

--- a/src/main/java/org/tudo/sse/analyses/MavenCentralLibraryAnalysis.java
+++ b/src/main/java/org/tudo/sse/analyses/MavenCentralLibraryAnalysis.java
@@ -24,11 +24,18 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+/**
+ * Base class for analyses that process <b>libraries</b> hosted on Maven Central. For each library, all artifacts (releases)
+ * are aggregated and enriched with pom / JAR information as specified by the implementing class.
+ */
 public abstract class MavenCentralLibraryAnalysis extends MavenCentralAnalysis {
 
     private final IReleaseListProvider releaseListProvider;
     private final ResolverFactory resolverFactory;
 
+    /**
+     * The configuration for this analysis instance. Only available after runAnalysis has been called.
+     */
     protected CommonConfigParser.CommonConfig config;
 
     private ActorRef queueActorRef;

--- a/src/main/java/org/tudo/sse/analyses/MavenCentralLibraryAnalysis.java
+++ b/src/main/java/org/tudo/sse/analyses/MavenCentralLibraryAnalysis.java
@@ -158,8 +158,10 @@ public abstract class MavenCentralLibraryAnalysis extends MavenCentralAnalysis {
     /**
      * Analysis lifecycle hook that is executed before a library is being processed, i.e., before any releases are
      * discovered.
+     * <p>
+     * <b>Note:</b>This method may be called concurrently by multiple threads if the analysis uses parallel execution
+     * </p>
      *
-     * @implNote This method may be called concurrently by multiple threads if the analysis uses parallel execution
      *
      * @param groupId The library's group ID
      * @param artifactId The library's artifact ID
@@ -171,8 +173,9 @@ public abstract class MavenCentralLibraryAnalysis extends MavenCentralAnalysis {
     /**
      * Analysis lifecycle hook that is executed after a library has been processed, i.e., after all releases have been
      * discovered and the analysis implementation has been executed.
-     *
-     * @implNote This method may be called concurrently by multiple threads if the analysis uses parallel execution
+     * <p>
+     * <b>Note:</b>This method may be called concurrently by multiple threads if the analysis uses parallel execution
+     * </p>
      *
      * @param groupId The library's group ID
      * @param artifactId The library's artifact ID
@@ -185,7 +188,9 @@ public abstract class MavenCentralLibraryAnalysis extends MavenCentralAnalysis {
     /**
      * Analysis lifecycle hook that is executed when the analysis failed to obtain a version list for a given library.
      *
-     * @implNote This method may be called concurrently by multiple threads if the analysis uses parallel execution
+     * <p>
+     * <b>Note:</b>This method may be called concurrently by multiple threads if the analysis uses parallel execution
+     * </p>
      *
      * @param groupId The library's group ID
      * @param artifactId The library's artifact ID

--- a/src/main/java/org/tudo/sse/model/jar/JarInformation.java
+++ b/src/main/java/org/tudo/sse/model/jar/JarInformation.java
@@ -186,43 +186,55 @@ public class JarInformation extends ArtifactInformation {
     }
 
     /**
+     * <p>
      * Retrieves a list of all class files contained in JAR file referenced by this ArtifactInformation. The class
      * files are returned as represented by the OPAL framework.
+     * </p>
+     * <p>
+     * <b>Note:</b> OPAL classes are not designed to be used in large scale analyses. Over time, OPAL's internal caches
+     * will continue to claim heap space that is never freed, so eventually the program will crash with an
+     * OutOfMemory error. There is currently no good way to avoid this, so use project instances only if you
+     * really need them.
+     * </p>
      * @return List of OPAL class file representations, or null if no JAR file was found
      * @throws IOException If reading the JAR file fails
-     * @implNote OPAL classes are not designed to be used in large scale analyses. Over time, OPAL's internal caches
-     *           will continue to claim heap space that is never freed, so eventually the program will crash with an
-     *           OutOfMemory error. There is currently no good way to avoid this, so use OPAL instances only if you
-     *           really need them.
      */
     public List<org.opalj.br.ClassFile> getOpalClassFileRepresentations() throws IOException {
         return getOpalClassFileRepresentations(this.ident);
     }
 
     /**
+     * <p>
      * Retrieves all class files for the JAR referenced by this ArtifactInformation, and uses them to initialize an
      * OPAL project instance. This instance can be used to conduct complex static program analyses.
+     * </p>
+     * <p>
+     * <b>Note:</b> OPAL projects are not designed to be used in large scale analyses. Over time, OPAL's internal caches
+     * will continue to claim heap space that is never freed, so eventually the program will crash with an
+     * OutOfMemory error. There is currently no good way to avoid this, so use project instances only if you
+     * really need them.
+     * </p>
      * @return The OPAL project instance, or null if no JAR file was found
      * @throws IOException If reading the JAR file fails
-     * @implNote OPAL projects are not designed to be used in large scale analyses. Over time, OPAL's internal caches
-     *           will continue to claim heap space that is never freed, so eventually the program will crash with an
-     *           OutOfMemory error. There is currently no good way to avoid this, so use project instances only if you
-     *           really need them.
      */
     public Project<String> getOpalProject() throws IOException {
         return getOpalProject(MarinOpalLogger.newInfoLogger(LogManager.getLogger("[OPAL-Project]")));
     }
 
     /**
+     * <p>
      * Retrieves all class files for the JAR referenced by this ArtifactInformation, and uses them to initialize an
      * OPAL project instance. This instance can be used to conduct complex static program analyses.
+     * </p>
+     * <p>
+     * <b>Note:</b> OPAL projects are not designed to be used in large scale analyses. Over time, OPAL's internal caches
+     * will continue to claim heap space that is never freed, so eventually the program will crash with an
+     * OutOfMemory error. There is currently no good way to avoid this, so use project instances only if you
+     * really need them.
+     * </p>
      * @return The OPAL project instance, or null if no JAR file was found
      * @param projectLogger A custom logger instance to configure the amount of output that is produced by OPAL.
      * @throws IOException If reading the JAR file fails
-     * @implNote OPAL projects are not designed to be used in large scale analyses. Over time, OPAL's internal caches
-     *           will continue to claim heap space that is never freed, so eventually the program will crash with an
-     *           OutOfMemory error. There is currently no good way to avoid this, so use project instances only if you
-     *           really need them.
      */
     public Project<String> getOpalProject(MarinOpalLogger projectLogger) throws IOException {
         try(JarInputStream jarStream = getJarInputStream()){

--- a/src/main/java/org/tudo/sse/model/pom/PomInformation.java
+++ b/src/main/java/org/tudo/sse/model/pom/PomInformation.java
@@ -9,9 +9,22 @@ import java.util.Map;
  * This class is where all the information collected during pom resolution is stored. From the raw features to resolved transitive dependencies.
  */
 public class PomInformation extends ArtifactInformation {
+
+    /**
+     * The raw, unresolved features specified in this pom file.
+     */
     protected RawPomFeatures rawPomFeatures;
+
+    /**
+     * List of artifacts that are imported via this artifact's pom file.
+     */
     protected List<Artifact> imports;
+
+    /**
+     * The parent specified by this artifact's pom file, or null if no parent is specified.
+     */
     protected Artifact parent;
+
     private List<Dependency> resolvedDependencies;
     private List<Artifact> allTransitiveDependencies;
     private List<Artifact> effectiveTransitiveDependencies;

--- a/src/main/java/org/tudo/sse/multithreading/ProcessLibraryMessage.java
+++ b/src/main/java/org/tudo/sse/multithreading/ProcessLibraryMessage.java
@@ -2,14 +2,25 @@ package org.tudo.sse.multithreading;
 
 import java.util.function.Supplier;
 
+/**
+ * Message used in multithreaded mode to queue processing of a callback method (for analyzing libraries).
+ */
 public class ProcessLibraryMessage implements WorkItem {
 
     private final Supplier<Void> processEntryCallback;
 
+    /**
+     * Creates a new message with the given callback method
+     * @param callback The callback that analyzes a library
+     */
     public ProcessLibraryMessage(Supplier<Void> callback) {
         this.processEntryCallback = callback;
     }
 
+    /**
+     * Returns the callback method stored in this message.
+     * @return The callback
+     */
     public Supplier<Void> getProcessEntryCallback() { return processEntryCallback; }
 
 }

--- a/src/main/java/org/tudo/sse/multithreading/WorkItem.java
+++ b/src/main/java/org/tudo/sse/multithreading/WorkItem.java
@@ -1,4 +1,7 @@
 package org.tudo.sse.multithreading;
 
+/**
+ * Marker interface for items of work relevant to the queue manager in multithreaded mode.
+ */
 public interface WorkItem {
 }

--- a/src/main/java/org/tudo/sse/multithreading/WorkItemFinishedMessage.java
+++ b/src/main/java/org/tudo/sse/multithreading/WorkItemFinishedMessage.java
@@ -1,11 +1,19 @@
 package org.tudo.sse.multithreading;
 
+/**
+ * A singleton message that is used in multithreaded mode to let the queue manager keep track of the number of completed
+ * work items (libraries or artifacts processed).
+ */
 public class WorkItemFinishedMessage {
 
     private static final WorkItemFinishedMessage _instance = new WorkItemFinishedMessage();
 
     private WorkItemFinishedMessage() {}
 
+    /**
+     * Retrieves the singleton instance of this message
+     * @return The singleton instance
+     */
     public static WorkItemFinishedMessage getInstance() {
         return _instance;
     }

--- a/src/main/java/org/tudo/sse/multithreading/WorkloadIsFinalMessage.java
+++ b/src/main/java/org/tudo/sse/multithreading/WorkloadIsFinalMessage.java
@@ -10,7 +10,10 @@ public class WorkloadIsFinalMessage {
 
     private WorkloadIsFinalMessage() {}
 
-
+    /**
+     * Retrieves the singleton instance of this message.
+     * @return The singleton instance.
+     */
     public static WorkloadIsFinalMessage getInstance(){
         if(_instance == null) _instance = new WorkloadIsFinalMessage();
         return _instance;

--- a/src/main/java/org/tudo/sse/resolution/releases/DefaultMavenReleaseListProvider.java
+++ b/src/main/java/org/tudo/sse/resolution/releases/DefaultMavenReleaseListProvider.java
@@ -24,7 +24,7 @@ import java.util.Objects;
  *
  * @author Johannes Düsing
  */
-public class DefaultMavenReleaseListProvider extends IReleaseListProvider{
+public class DefaultMavenReleaseListProvider implements IReleaseListProvider{
 
     private final MetadataXpp3Reader reader = new MetadataXpp3Reader();
     private final MavenCentralRepository mavenRepo = MavenCentralRepository.getInstance();

--- a/src/main/java/org/tudo/sse/resolution/releases/IReleaseListProvider.java
+++ b/src/main/java/org/tudo/sse/resolution/releases/IReleaseListProvider.java
@@ -10,7 +10,7 @@ import java.util.Objects;
  * Interface defining functionality to obtain a list of Maven Central releases (i.e. version numbers) for a given
  * library (i.e. GA-Tuple).
  */
-public abstract class IReleaseListProvider {
+public interface IReleaseListProvider {
 
     /**
      * Gets the ordered list of releases (i.e. version numbers) for the given identifier. The identifier's version is
@@ -20,7 +20,7 @@ public abstract class IReleaseListProvider {
      * @return List of version numbers as ordered by the underlying source
      * @throws IOException If a connection error occurs
      */
-    public List<String> getReleases(ArtifactIdent identifier) throws IOException{
+    default List<String> getReleases(ArtifactIdent identifier) throws IOException{
         Objects.requireNonNull(identifier);
 
         return getReleases(identifier.getGroupID(), identifier.getArtifactID());
@@ -34,5 +34,5 @@ public abstract class IReleaseListProvider {
      * @return List of version numbers as ordered by the underlying source
      * @throws IOException If a connection error occurs
      */
-    public abstract List<String> getReleases(String groupId, String artifactId) throws IOException;
+    List<String> getReleases(String groupId, String artifactId) throws IOException;
 }

--- a/src/main/java/org/tudo/sse/utils/ArtifactConfigParser.java
+++ b/src/main/java/org/tudo/sse/utils/ArtifactConfigParser.java
@@ -4,8 +4,24 @@ import org.tudo.sse.CLIException;
 
 import java.nio.file.Path;
 
+/**
+ * Parser for ArtifactConfig objects, i.e. configurations of the {@link org.tudo.sse.analyses.MavenCentralArtifactAnalysis}.
+ * Configuration is obtained by parsing command line arguments provided as an array of strings.
+ */
 public class ArtifactConfigParser extends CommonConfigParser implements CLIParsingUtilities {
 
+    /**
+     * Creates a new artifact config parser instance.
+     */
+    public ArtifactConfigParser() { super(); }
+
+    /**
+     * Parses a given array containing JVM command line arguments into an {@link ArtifactConfig} object. Throws an exception
+     * if the given arguments are not valid.
+     * @param args Array of command line arguments, as passed by the JVM
+     * @return Corresponding {@link ArtifactConfig} if parsing was successful
+     * @throws CLIException If parsing failed. Contains details about the specific argument that was invalid.
+     */
     public ArtifactConfig parseArtifactConfig(String[] args) throws CLIException {
         final ArtifactConfig artifactConfig = new ArtifactConfig();
 
@@ -59,14 +75,34 @@ public class ArtifactConfigParser extends CommonConfigParser implements CLIParsi
         }
     }
 
+    /**
+     * Class representing the configuration of a {@link org.tudo.sse.analyses.MavenCentralArtifactAnalysis} instance.
+     */
     public static class ArtifactConfig extends CommonConfig {
 
+        /**
+         * Timestamp before which artifacts shall be excluded from analysis, or -1 if disabled.
+         */
         public long since;
+
+        /**
+         * Timestamp after which artifacts shall be excluded from analysis, or -1 if disabled.
+         */
         public long until;
 
+        /**
+         * Directory to write file outputs to, or null if disabled.
+         */
         public Path outputDirectory;
+
+        /**
+         * Whether files shall be written to the output directory.
+         */
         public boolean outputEnabled;
 
+        /**
+         * Creates a new configuration object with default values.
+         */
         public ArtifactConfig(){
             super();
 

--- a/src/main/java/org/tudo/sse/utils/CLIParsingUtilities.java
+++ b/src/main/java/org/tudo/sse/utils/CLIParsingUtilities.java
@@ -6,8 +6,19 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+/**
+ * Interface providing default implementations for parsing command line arguments.
+ */
 interface CLIParsingUtilities {
 
+    /**
+     * Parses the next argument from the given array of arguments as an integer value and returns it.
+     *
+     * @param args The CLI arguments
+     * @param i The current parsing position
+     * @return The <b>next</b> argument at position i+1 as an integer value
+     * @throws CLIException If there is no next argument, or it is not a valid integer
+     */
     default int nextArgAsInt(String[] args, int i) throws CLIException {
         if(i + 1 < args.length) {
             try{
@@ -20,6 +31,15 @@ interface CLIParsingUtilities {
         }
     }
 
+    /**
+     * Parses the next argument from the given array of arguments as a pair of long values, separated by a colon. The
+     * pair is returned as a long-array of size 2.
+     *
+     * @param args The CLI arguments
+     * @param i The current parsing position
+     * @return The <b>next</b> argument at position i+1 as a pair of long values
+     * @throws CLIException If there is no next argument, or it is not formatted as two long values separated by a colon.
+     */
     default long[] nextArgAsLongPair(String[] args, int i) throws CLIException {
         long[] toReturn = new long[2];
         if(i + 1 < args.length) {
@@ -40,6 +60,14 @@ interface CLIParsingUtilities {
         return toReturn;
     }
 
+    /**
+     * Parses the next argument from the given array of arguments as a Path value.
+     *
+     * @param args The CLI arguments
+     * @param i The current parsing position
+     * @return The <b>next</b> argument at position i+1 as a Path
+     * @throws CLIException If there is no next argument
+     */
     default Path nextArgAsPath(String[] args, int i) throws CLIException {
         if(i + 1 < args.length) {
             return Paths.get(args[i + 1]);
@@ -48,6 +76,14 @@ interface CLIParsingUtilities {
         }
     }
 
+    /**
+     * Parses the next argument from the given array of arguments as a Path and ensures that it references a regular file.
+     *
+     * @param args The CLI arguments
+     * @param i The current parsing position
+     * @return The <b>next</b> argument at position i+1 as a Path that is guaranteed to point to a regular file
+     * @throws CLIException If there is no next argument, or it does not point to a file (i.e. directory), or it does not exist
+     */
     default Path nextArgAsRegularFileReference(String[] args, int i) throws CLIException {
         final Path path = nextArgAsPath(args, i);
         if(Files.isRegularFile(path))
@@ -56,6 +92,13 @@ interface CLIParsingUtilities {
             throw new CLIException("Expected an existing file but got: " + path, args[i]);
     }
 
+    /**
+     * Parses the next argument from the given array of arguments as a Path and ensures that it references a directory.
+     * @param args The CLI arguments
+     * @param i The current parsing position
+     * @return The <b>next</b> argument at position i+1 as a Path that is guaranteed to point to a directory
+     * @throws CLIException If there is no next argument, or it does not point to a directory, or it does not exist
+     */
     default Path nextArgAsDirectoryReference(String[] args, int i) throws CLIException {
         final Path path = nextArgAsPath(args, i);
         if(Files.isDirectory(path))

--- a/src/main/java/org/tudo/sse/utils/CommonConfigParser.java
+++ b/src/main/java/org/tudo/sse/utils/CommonConfigParser.java
@@ -5,8 +5,24 @@ import org.tudo.sse.CLIException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+/**
+ * Parser for {@link CommonConfig} objects, i.e. configurations of the {@link org.tudo.sse.analyses.MavenCentralLibraryAnalysis}.
+ * Configuration is obtained by parsing command line arguments provided as an array of strings.
+ */
 public class CommonConfigParser implements CLIParsingUtilities {
 
+    /**
+     * Creates a new artifact config parsers instance.
+     */
+    public CommonConfigParser() { super(); }
+
+    /**
+     * Parses a given array containing JVM command line arguments into an {@link CommonConfig} objects. Throws an exception
+     * if the given arguments are not valid.
+     * @param args Array of command line arguments, as passed by the JVM
+     * @return Corresponding {@link CommonConfig} if parsing was successful
+     * @throws CLIException If parsing failed. Contains details about the specific argument that was invalid.
+     */
     public CommonConfig parseCommonConfig(String[] args) throws CLIException {
         final CommonConfig config = new CommonConfig();
 
@@ -18,7 +34,14 @@ public class CommonConfigParser implements CLIParsingUtilities {
         return config;
     }
 
-    protected void handleParameter(String[] args, int i, CommonConfig config) throws CLIException{
+    /**
+     * Parses a given parameter from the array of CLI arguments and applies it to the config object.
+     * @param args CLI arguments array
+     * @param i Current parsing position
+     * @param config Current configuration object
+     * @throws CLIException If parsing the current argument fails.
+     */
+    protected void handleParameter(String[] args, int i, CommonConfig config) throws CLIException {
         switch (args[i]){
             case "-st":
             case "--skip-take":
@@ -61,19 +84,54 @@ public class CommonConfigParser implements CLIParsingUtilities {
         }
     }
 
+    /**
+     * Class representing the configuration of a {@link org.tudo.sse.analyses.MavenCentralLibraryAnalysis} instance.
+     */
     public static class CommonConfig {
+
+        /**
+         * Number of artifacts to skip from the underlying source, or -1 if disabled.
+         */
         public long skip;
+
+        /**
+         * Number of artifacts to take from the underlying source, or -1 if no limit shall be applied.
+         */
         public long take;
 
+        /**
+         * Path to read inputs from, instead of accessing the Maven Central index. Null if the index shall be used.
+         */
         public Path inputListFile;
+
+        /**
+         * File path to output analysis progress to.
+         */
         public Path progressOutputFile;
+
+        /**
+         * Path to read previous progress from, in order to restore it. Null if disabled.
+         */
         public Path progressRestoreFile;
 
+        /**
+         * True if multiple threads shall be used, false for single-threaded analysis.
+         */
         public boolean multipleThreads;
+
+        /**
+         * Number of threads to use.
+         */
         public int threadCount;
 
+        /**
+         * Interval of entities after which progress shall be saved. Defaults to 100.
+         */
         public int progressWriteInterval;
 
+        /**
+         * Creates a new configuration with default values.
+         */
         public CommonConfig() {
             skip = -1L;
             take = -1L;

--- a/src/main/java/org/tudo/sse/utils/FileBasedArtifactIterator.java
+++ b/src/main/java/org/tudo/sse/utils/FileBasedArtifactIterator.java
@@ -7,12 +7,20 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Iterator;
 
+/**
+ * Iterator that reads Maven Central artifact identifiers from a text file. Expects one colon-separated triple of
+ * groupID:artifactID:version per line.
+ */
 public class FileBasedArtifactIterator implements Iterator<ArtifactIdent> {
 
     private final Path inputPath;
 
     private Iterator<String> lineIterator;
 
+    /**
+     * Creates a new iterator instance for the given file path.
+     * @param input Path to a text file containing GAV triples
+     */
     public FileBasedArtifactIterator(Path input){
         this.inputPath = input;
     }

--- a/src/main/java/org/tudo/sse/utils/LibraryIndexIterator.java
+++ b/src/main/java/org/tudo/sse/utils/LibraryIndexIterator.java
@@ -13,6 +13,10 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
+/**
+ * Iterator over all unique library names in the Maven Central index. A library name is a tuple of GroupId:ArtifactId,
+ * separated by a colon.
+ */
 public class LibraryIndexIterator implements Iterator<String>, AutoCloseable {
 
     private final Logger logger = LogManager.getLogger(getClass());
@@ -28,6 +32,11 @@ public class LibraryIndexIterator implements Iterator<String>, AutoCloseable {
     private String currentLibraryGA;
     private String nextLibraryGA;
 
+    /**
+     * Creates a new iterator instance for the given Maven repository.
+     * @param baseUri URI of the Maven-complient repository to iterator over
+     * @throws IOException If accessing the repository fails.
+     */
     public LibraryIndexIterator(URI baseUri) throws IOException {
         this.libraryHashesSeen = new HashSet<>();
 
@@ -43,12 +52,19 @@ public class LibraryIndexIterator implements Iterator<String>, AutoCloseable {
     }
 
 
+    /**
+     * Sets this iterator to a specific position by skipping over the given amount of entries. Aborts early if no more
+     * entries are available on the iterator.
+     *
+     * @param startIdx The iterator position to skip to
+     */
     public void setPosition(long startIdx){
         while(this.currentPosition < startIdx && this.hasNext()){
             this.next();
         }
     }
 
+    @Override
     public boolean hasNext() {
         // If currentLibraryGA is null, we have the first hasNext() call after a call to next(). We must find our new
         // currentLibraryGA first.
@@ -74,6 +90,7 @@ public class LibraryIndexIterator implements Iterator<String>, AutoCloseable {
         return this.nextLibraryGA != null;
     }
 
+    @Override
     public String next() {
         if(hasNext()){
             final String valueToReturn = this.currentLibraryGA;

--- a/src/main/java/org/tudo/sse/utils/MavenCentralRepository.java
+++ b/src/main/java/org/tudo/sse/utils/MavenCentralRepository.java
@@ -16,7 +16,14 @@ import java.nio.charset.StandardCharsets;
  */
 public final class MavenCentralRepository {
 
+    /**
+     * The Maven Central repository base path.
+     */
     public static final String RepoBasePath = "https://repo1.maven.org/maven2/";
+
+    /**
+     * The URI representing this repository's base path.
+     */
     public static final URI RepoBaseURI = URI.create(RepoBasePath);
 
     private static MavenCentralRepository theInstance = null;
@@ -43,6 +50,7 @@ public final class MavenCentralRepository {
      * @return An input stream for the library's version list XML file
      * @throws IOException If accessing the resource fails
      * @throws FileNotFoundException If the library does not exist / does not have a version list file
+     * @throws URISyntaxException If groupId or artifactId contained invalid URI characters
      */
     public InputStream openXMLFileInputStream(String groupId, String artifactId)
             throws IOException, FileNotFoundException, URISyntaxException{


### PR DESCRIPTION
This PR changes the build configuration so that our CI builds fail if either `javac` encounteres a warning (including linter warnings) or there are missing JavaDoc comments. To comply with this, the PR also completes all missing JavaDoc to this point. In the future, CI will fail on a Pull Request if it does not keep the JavaDoc up-to-date, which hopefully means that our documentation will stay somewhat relevant.

Closes #38 