### PR TITLE
Fix stack overflow error for circular dependencies

### DIFF
--- a/src/main/java/org/tudo/sse/model/ResolutionContext.java
+++ b/src/main/java/org/tudo/sse/model/ResolutionContext.java
@@ -28,10 +28,17 @@ public abstract class ResolutionContext {
     protected final Map<ArtifactIdent, Artifact> artifactsResolved;
 
     /**
+     * Set of artifact identifiers that are currently being under resolution by any Resolver. Helps avoid infinite
+     * resolution loops.
+     */
+    protected final Set<ArtifactIdent> currentlyResolving;
+
+    /**
      * Builds a new ResolutionContext instance.
      */
     protected ResolutionContext(){
         this.artifactsResolved = new HashMap<>();
+        this.currentlyResolving = new HashSet<>();
     }
 
     /**
@@ -65,6 +72,31 @@ public abstract class ResolutionContext {
      */
     public Set<Artifact> getAllArtifactsResolved(){
         return new HashSet<>(artifactsResolved.values());
+    }
+
+    /**
+     * Check whether the given artifact identifier is currently being resolved in this context.
+     * @param ident Artifact identifier to check
+     * @return True if this identifier is currently being resolved, false otherwise
+     */
+    public boolean isCurrentlyResolving(ArtifactIdent ident){
+        return this.currentlyResolving.contains(ident);
+    }
+
+    /**
+     * Mark the given artifact identifier as currently being resolved in this context.
+     * @param ident The identifier to mark
+     */
+    public void setIsCurrentlyResolving(ArtifactIdent ident){
+        this.currentlyResolving.add(ident);
+    }
+
+    /**
+     * Mark the given artifact identifier as not being resolved anymore in this context.
+     * @param ident The identifier to mark
+     */
+    public void setIsFinishedResolving(ArtifactIdent ident){
+        this.currentlyResolving.remove(ident);
     }
 
 }

--- a/src/main/java/org/tudo/sse/resolution/PomResolver.java
+++ b/src/main/java/org/tudo/sse/resolution/PomResolver.java
@@ -352,9 +352,18 @@ public class PomResolver {
     public Artifact processArtifact(ArtifactIdent identifier, ResolutionContext ctx) throws PomResolutionException, FileNotFoundException, IOException {
         final Artifact currentArtifact = ctx.createArtifact(identifier);
 
+        // If resolution on this artifact already begun (because, e.g. we are in an infinite dependency loop),
+        // we do not re-start resolution, but just return the artifact object - it will be fully resolved
+        // eventually
+        if(ctx.isCurrentlyResolving(identifier))
+            return currentArtifact;
+
         // Only build pom information if it is not already present for the current resolution context
         if(currentArtifact.hasPomInformation())
             return currentArtifact;
+
+        // Record that we are currently resolving this artifact
+        ctx.setIsCurrentlyResolving(identifier);
 
         PomInformation pomInformation = new PomInformation(identifier);
 
@@ -362,7 +371,11 @@ public class PomResolver {
         try(InputStream is = MavenRepo.openPomFileInputStream(identifier) ) {
             rawPomFeatures = processRawPomFeatures(is, identifier);
         } catch (SocketException e) {
+            ctx.setIsFinishedResolving(identifier);
             throw new PomResolutionException(e.getMessage(), identifier, e);
+        } catch(Exception x){
+            ctx.setIsFinishedResolving(identifier);
+            throw x;
         }
 
         ArtifactIdent relocation = null;
@@ -381,6 +394,9 @@ public class PomResolver {
 
         // Finally set pom information for current artifact, then return
         currentArtifact.setPomInformation(pomInformation);
+
+        // Record that we are no longer currently resolving this artifact
+        ctx.setIsFinishedResolving(identifier);
 
         return currentArtifact;
     }
@@ -540,18 +556,22 @@ public class PomResolver {
 
             if(current.getImports() != null) {
                 for(Artifact anImport : current.getImports()) {
-                    if(anImport.getPomInformation().getRawPomFeatures().getDependencyManagement() != null) {
-                        Tuple2<String, String> depStuff = findGA(missingVersion, anImport.getPomInformation().getRawPomFeatures().getDependencyManagement());
-                        if(depStuff != null) {
-                            if(depStuff._2 != null) {
-                                toReturn.setScope(depStuff._2);
-                                return toReturn;
+                    // Import resolution may have failed because of invalid import specifications. In that case, no POM
+                    // information will be present. We only try to expand imports for which we have pom information.
+                    if(anImport.hasPomInformation()) {
+                        if(anImport.getPomInformation().getRawPomFeatures().getDependencyManagement() != null) {
+                            Tuple2<String, String> depStuff = findGA(missingVersion, anImport.getPomInformation().getRawPomFeatures().getDependencyManagement());
+                            if(depStuff != null) {
+                                if(depStuff._2 != null) {
+                                    toReturn.setScope(depStuff._2);
+                                    return toReturn;
+                                }
                             }
                         }
-                    }
-                    toReturn = recursiveHandler(anImport.getPomInformation(), toReturn);
-                    if(toReturn.getScope() != null) {
-                        return toReturn;
+                        toReturn = recursiveHandler(anImport.getPomInformation(), toReturn);
+                        if(toReturn.getScope() != null) {
+                            return toReturn;
+                        }
                     }
                 }
             }
@@ -629,21 +649,25 @@ public class PomResolver {
 
             if(!parentResolved && current.getImports() != null) {
                 for(Artifact anImport : current.getImports()) {
-                    if(anImport.getPomInformation().getRawPomFeatures().getDependencyManagement() != null) {
-                        Tuple2<String, String> depStuff = findGA(missingVersion, anImport.getPomInformation().getRawPomFeatures().getDependencyManagement());
-                        if(depStuff != null) {
-                            version = depStuff._1;
-                            if(depStuff._2 != null && toReturn.getScope() == null) {
-                                toReturn.setScope(depStuff._2);
+                    // Import resolution may have failed because of invalid import specifications. In that case, no POM
+                    // information will be present. We only try to expand imports for which we have pom information.
+                    if(anImport.hasPomInformation()){
+                        if(anImport.getPomInformation().getRawPomFeatures().getDependencyManagement() != null) {
+                            Tuple2<String, String> depStuff = findGA(missingVersion, anImport.getPomInformation().getRawPomFeatures().getDependencyManagement());
+                            if(depStuff != null) {
+                                version = depStuff._1;
+                                if(depStuff._2 != null && toReturn.getScope() == null) {
+                                    toReturn.setScope(depStuff._2);
+                                }
+                                toReturn.getIdent().setVersion(version);
+                                current = anImport.getPomInformation();
                             }
-                            toReturn.getIdent().setVersion(version);
-                            current = anImport.getPomInformation();
                         }
-                    }
-                    if(version == null) {
-                        toReturn = recursiveHandler(anImport.getPomInformation(), toReturn);
-                        curIdent = toReturn.getIdent();
-                        version = curIdent.getVersion();
+                        if(version == null) {
+                            toReturn = recursiveHandler(anImport.getPomInformation(), toReturn);
+                            curIdent = toReturn.getIdent();
+                            version = curIdent.getVersion();
+                        }
                     }
                 }
             }

--- a/src/test/java/org/tudo/sse/resolution/PomResolverTest.java
+++ b/src/test/java/org/tudo/sse/resolution/PomResolverTest.java
@@ -401,4 +401,18 @@ class PomResolverTest {
             }
         }
     }
+
+    @Test
+    @DisplayName("The POM resolver must not loop for circular dependencies")
+    void resolveDependencyLoop() {
+        // Based on https://github.com/sse-labs/marin/issues/52
+        final ArtifactIdent loopingArtifact = new ArtifactIdent("net.wicp.tams", "ts-maven-plugin", "8.0.2");
+        final ArtifactResolutionContext freshCtx = ArtifactResolutionContext.newInstance(loopingArtifact);
+
+        final Artifact artifact = pomResolver.resolveArtifacts(List.of(loopingArtifact), freshCtx).get(0);
+
+        assertNotNull(artifact);
+
+
+    }
 }


### PR DESCRIPTION
#52 reported an issue for certain configurations of circular dependencies, where MARIN would run into infinite loops. This PR fixes the issue by using the resolution contexts to keep track of artifacts that are currently being resolved, but not yet finished resolving. This (plus the fact that artifact objects are unique per identifier within their context) allows us to not enter circular resolution loops.

The particular identifier that was causing problems in #52 has been added as a test case for this functionality.