### PR TITLE
Create Default Progress Restore File

### DIFF
--- a/src/main/java/org/tudo/sse/analyses/config/LibraryAnalysisConfigBuilder.java
+++ b/src/main/java/org/tudo/sse/analyses/config/LibraryAnalysisConfigBuilder.java
@@ -3,8 +3,10 @@ package org.tudo.sse.analyses.config;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 
 /**
  * Configuration builder to obtain {@link LibraryAnalysisConfig} instances programmatically.
@@ -120,7 +122,20 @@ public class LibraryAnalysisConfigBuilder {
      * @throws InvalidConfigurationException If the given configuration value is not valid
      */
     public LibraryAnalysisConfigBuilder withProgressRestoreFile(Path restoreFile) throws InvalidConfigurationException {
-        if(restoreFile == null || !Files.isRegularFile(restoreFile))
+
+        boolean fileExists = Files.isRegularFile(restoreFile);
+
+        if(!fileExists){
+            try {
+                log.info("Progress restore file does not yet exists, creating default at {}", restoreFile.toAbsolutePath());
+                Files.write(restoreFile, "0".getBytes(), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+                fileExists = true;
+            } catch(IOException iox){
+                log.warn("Failed to create restore file", iox);
+            }
+        }
+
+        if(!fileExists)
             throw new InvalidConfigurationException("progress-restore-file", "Restore file must be a valid file reference");
 
         if(this.theConfig.progressRestoreFile != LibraryAnalysisConfig.DEFAULT_VALUE_PROGRESS_RESTORE_FILE)

--- a/src/main/java/org/tudo/sse/analyses/config/parsing/LibraryAnalysisConfigParser.java
+++ b/src/main/java/org/tudo/sse/analyses/config/parsing/LibraryAnalysisConfigParser.java
@@ -53,7 +53,7 @@ public class LibraryAnalysisConfigParser implements CLIParsingUtilities {
                     break;
                 case "-prf":
                 case "--progress-restore-file":
-                    configBuilder.withProgressRestoreFile(nextArgAsRegularFileReference(args, i));
+                    configBuilder.withProgressRestoreFile(nextArgAsPath(args, i));
                     break;
                 case "-spi":
                 case "--save-progress-interval":

--- a/src/test/java/org/tudo/sse/analyses/MavenCentralLibraryAnalysisTest.java
+++ b/src/test/java/org/tudo/sse/analyses/MavenCentralLibraryAnalysisTest.java
@@ -7,6 +7,7 @@ import org.tudo.sse.analyses.config.LibraryAnalysisConfig;
 import org.tudo.sse.model.Artifact;
 import org.tudo.sse.analyses.config.parsing.LibraryAnalysisConfigParser;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -70,11 +71,26 @@ public class MavenCentralLibraryAnalysisTest {
     }
 
     @Test
-    @DisplayName("The CLI parser must fail if input files do not exist")
-    void parseNonExistingFile(){
-        final String validArgs = "--progress-restore-file foo.input";
+    @DisplayName("The CLI parser must create a default progress restore file with progress 0 if file does not exist")
+    void parseNonExistingFile() throws IOException {
+        final String fileRef = "foo.input";
+        final File nonExistingInput = new File(fileRef);
 
-        assertThrows(RuntimeException.class, () -> parseCLI(validArgs));
+        Files.deleteIfExists(nonExistingInput.toPath());
+
+        assertFalse(nonExistingInput.exists());
+
+        final String validArgs = "--progress-restore-file " + fileRef;
+
+        final LibraryAnalysisConfig config = parseCLI(validArgs);
+
+        assertEquals(nonExistingInput.toPath(), config.progressRestoreFile);
+        assertTrue(nonExistingInput.exists());
+
+        String content = Files.readString(nonExistingInput.toPath());
+        assertEquals("0", content);
+
+        Files.deleteIfExists(nonExistingInput.toPath());
     }
 
     @Test


### PR DESCRIPTION
As requested by @finnwilken in #50, it would be nice if the progress restore file (PRF) were automatically created on startup if it does not yet exist. This PR implements the desired functionality: If the PRF does not exist on startup, MARIN will create it and assign a default value of `"0"`, i.e. no progress to be restored. The corresponding expected behavior in the respective test is also adapted.

Closes #50.